### PR TITLE
Add write_to_buffer & support different header types

### DIFF
--- a/c_src/g_object/g_boxed.c
+++ b/c_src/g_object/g_boxed.c
@@ -35,6 +35,8 @@ ERL_NIF_TERM boxed_to_erl_term(ErlNifEnv *env, gpointer ptr, GType type) {
 
   boxed_r = enif_alloc_resource(G_BOXED_RT, sizeof(GBoxedResource));
 
+  // TODO: use elixir-struct instead of c-struct, so that type
+  // information is visible in elixir
   boxed_r->boxed_type = type;
   boxed_r->boxed_ptr = ptr;
 

--- a/c_src/g_object/g_object.c
+++ b/c_src/g_object/g_object.c
@@ -13,6 +13,9 @@ ERL_NIF_TERM g_object_to_erl_term(ErlNifEnv *env, GObject *obj) {
   GObjectResource *gobject_r;
 
   gobject_r = enif_alloc_resource(G_OBJECT_RT, sizeof(GObjectResource));
+
+  // TODO: Keep gtype name and use elixir-struct instead of c-struct,
+  // so that type information is visible in elixir.
   gobject_r->obj = obj;
 
   term = enif_make_resource(env, gobject_r);

--- a/c_src/g_object/g_value.c
+++ b/c_src/g_object/g_value.c
@@ -245,14 +245,19 @@ static VixResult get_double(ErlNifEnv *env, GValue *gvalue) {
   double double_value;
 
   double_value = g_value_get_double(gvalue);
-  return vix_result(enif_make_int(env, double_value));
+
+  /*
+   * NOTE: erlang does not support NaN & infinity, we only handle finite double
+   * value. see: https://erlang.org/doc/man/erl_nif.html#enif_make_double
+   */
+  return vix_result(enif_make_double(env, double_value));
 }
 
 static VixResult get_boxed(ErlNifEnv *env, GValue *gvalue) {
   gpointer ptr;
   GType type;
 
-  // duplicate value so that we we can free it ourselves
+  // duplicate value so that we can free it ourselves
   ptr = g_value_dup_boxed(gvalue);
   type = G_VALUE_TYPE(gvalue);
 

--- a/c_src/g_object/g_value.h
+++ b/c_src/g_object/g_value.h
@@ -9,7 +9,10 @@
 VixResult set_g_value_from_erl_term(ErlNifEnv *env, GParamSpec *pspec,
                                     ERL_NIF_TERM term, GValue *gvalue);
 
-VixResult get_erl_term_from_g_value(ErlNifEnv *env, GObject *obj,
-                                    const char *name, GParamSpec *pspec);
+VixResult get_erl_term_from_g_object_property(ErlNifEnv *env, GObject *obj,
+                                              const char *name,
+                                              GParamSpec *pspec);
+
+VixResult g_value_to_erl_term(ErlNifEnv *env, GValue gvalue);
 
 #endif

--- a/c_src/vips_image.h
+++ b/c_src/vips_image.h
@@ -9,6 +9,9 @@ ERL_NIF_TERM nif_image_new_from_file(ErlNifEnv *env, int argc,
 ERL_NIF_TERM nif_image_write_to_file(ErlNifEnv *env, int argc,
                                      const ERL_NIF_TERM argv[]);
 
+ERL_NIF_TERM nif_image_write_to_buffer(ErlNifEnv *env, int argc,
+                                       const ERL_NIF_TERM argv[]);
+
 ERL_NIF_TERM nif_image_new(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM nif_image_new_temp_file(ErlNifEnv *env, int argc,

--- a/c_src/vips_operation.c
+++ b/c_src/vips_operation.c
@@ -138,7 +138,8 @@ static VixResult get_operation_properties(ErlNifEnv *env, VipsOperation *op) {
         return vix_error(env, "failed to get output argument");
       }
 
-      res = get_erl_term_from_g_value(env, G_OBJECT(op), names[i], pspec);
+      res = get_erl_term_from_g_object_property(env, G_OBJECT(op), names[i],
+                                                pspec);
 
       if (!res.is_success)
         return res;

--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -58,6 +58,7 @@ static ErlNifFunc nif_funcs[] = {
      ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"nif_image_write_to_file", 2, nif_image_write_to_file,
      ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"nif_image_write_to_buffer", 2, nif_image_write_to_buffer, 0},
     {"nif_image_new", 0, nif_image_new, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"nif_image_new_temp_file", 1, nif_image_new_temp_file,
      ERL_NIF_DIRTY_JOB_IO_BOUND},

--- a/lib/vix/nif.ex
+++ b/lib/vix/nif.ex
@@ -21,6 +21,9 @@ defmodule Vix.Nif do
   def nif_image_write_to_file(_vips_image, _dst),
     do: :erlang.nif_error(:nif_library_not_loaded)
 
+  def nif_image_write_to_buffer(_vips_image, _suffix),
+    do: :erlang.nif_error(:nif_library_not_loaded)
+
   def nif_image_new(),
     do: :erlang.nif_error(:nif_library_not_loaded)
 

--- a/lib/vix/type.ex
+++ b/lib/vix/type.ex
@@ -53,9 +53,11 @@ defmodule Vix.Type do
         Vips.Target
 
       {"GParamEnum", enum_type} ->
+        # TODO: convert type in nif itself, see `get_enum_as_atom`
         Module.concat(Vix.Vips.Enum, String.to_atom(enum_type))
 
       {"GParamFlags", flag_type} ->
+        # TODO: convert type in nif itself, see `get_flags_as_atoms`
         Module.concat(Vix.Vips.Flag, String.to_atom(flag_type))
 
       {_, "gint"} ->

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -226,7 +226,7 @@ defmodule Vix.Vips.Image do
   end
 
   for name <-
-        ~w/width height bands xres yres xoffset yoffset filename mode scale offset page_height n_pages orientation/ do
+        ~w/width height bands xres yres xoffset yoffset filename mode scale offset page_height n_pages orientation interpretation coding format/ do
     func_name = String.to_atom(name)
 
     @doc """

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -157,15 +157,18 @@ defmodule Vix.Vips.Image do
     func_name = String.to_atom(name)
 
     @doc """
-    Get #{name}
+    Get #{name} of the the image
 
     see: https://libvips.github.io/libvips/API/current/libvips-header.html#vips-image-get-#{
       String.replace(name, "_", "-")
     }
     """
-    @spec unquote(func_name)(__MODULE__.t()) :: {:ok, term()} | {:error, term()}
+    @spec unquote(func_name)(__MODULE__.t()) :: term() | no_return()
     def unquote(func_name)(vips_image) do
-      header_value(vips_image, unquote(name))
+      case header_value(vips_image, unquote(name)) do
+        {:ok, value} -> value
+        {:error, error} -> raise error
+      end
     end
   end
 

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -77,6 +77,27 @@ defmodule Vix.Vips.Image do
   end
 
   @doc """
+  Returns `vips_image` as binary based on the format specified by `suffix`. This function is similar to `write_to_file` but instead of writing the output to the file, it returns it as a binary.
+
+  Save options may be encoded in the filename or given as a hash. For example:
+
+  ```elixir
+  Image.write_to_buffer(vips_image, ".jpg[Q=90]")
+  ```
+
+  The full set of save options depend on the selected saver. You can get list of available options for the saver
+
+  ```shell
+  $ vips jpegsave
+  ```
+  """
+  @spec write_to_buffer(__MODULE__.t(), String.t()) ::
+          {:ok, binary()} | {:error, term()}
+  def write_to_buffer(vips_image, suffix) do
+    Nif.nif_image_write_to_buffer(vips_image, normalize_string(suffix))
+  end
+
+  @doc """
   Make a VipsImage which, when written to, will create a temporary file on disc.
 
   The file will be automatically deleted when the image is destroyed. format is something like `"%s.v"` for a vips file.

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -26,7 +26,7 @@ defmodule Vix.Vips.ImageTest do
   end
 
   test "new_matrix_from_array", %{dir: _dir} do
-    assert {:ok, mat} =
+    assert {:ok, _} =
              Image.new_matrix_from_array(3, 3, [[-1, -1, -1], [-1, 16, -1], [-1, -1, -1]])
   end
 
@@ -64,6 +64,6 @@ defmodule Vix.Vips.ImageTest do
 
   test "macro generated function", %{dir: _dir} do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-    assert {:ok, 518} = Image.width(im)
+    assert 518 == Image.width(im)
   end
 end

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -65,6 +65,7 @@ defmodule Vix.Vips.ImageTest do
   test "macro generated function", %{dir: _dir} do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert 518 == Image.width(im)
+    assert :VIPS_INTERPRETATION_sRGB == Image.interpretation(im)
   end
 
   test "write image to buffer", %{dir: _dir} do

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -72,4 +72,46 @@ defmodule Vix.Vips.ImageTest do
     {:ok, _bin} = Image.write_to_buffer(im, ".jpg[Q=90]")
   end
 
+  test "display" do
+    {:ok, io_device} = StringIO.open("")
+
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    assert ^im = Image.display(im, io_device: io_device)
+
+    {:ok, {"", image_data}} = StringIO.close(io_device)
+
+    assert_output_to_terminal("unnamed.jpg", image_data)
+  end
+
+  test "display options" do
+    {:ok, io_device} = StringIO.open("")
+
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    im = Vix.Vips.Operation.invert!(im)
+
+    assert ^im = Image.display(im, io_device: io_device, label: "cute_puppies", suffix: ".png")
+
+    {:ok, {"", image_data}} = StringIO.close(io_device)
+
+    assert_output_to_terminal("cute_puppies.png", image_data)
+  end
+
+  defp assert_output_to_terminal(expected_name, image_data) do
+    assert "\e]1337;File=" <> data = image_data
+    [args, image_data] = String.split(data, ":", parts: 2)
+
+    args =
+      String.split(args, ";")
+      |> Map.new(fn kv ->
+        [key, value] = String.split(kv, "=", parts: 2)
+        {key, value}
+      end)
+
+    assert %{"name" => encoded_name, "size" => size, "inline" => "1"} = args
+
+    assert expected_name == Base.decode64!(encoded_name)
+    assert {size, ""} = Integer.parse(size)
+
+    assert <<_::binary-size(size), "\a">> = image_data
+  end
 end

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -66,4 +66,10 @@ defmodule Vix.Vips.ImageTest do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert 518 == Image.width(im)
   end
+
+  test "write image to buffer", %{dir: _dir} do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    {:ok, _bin} = Image.write_to_buffer(im, ".jpg[Q=90]")
+  end
+
 end

--- a/test/vix/vips/operation_test.exs
+++ b/test/vix/vips/operation_test.exs
@@ -60,7 +60,7 @@ defmodule Vix.Vips.OperationTest do
   test "additional return values", %{dir: _dir} do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
 
-    assert {:ok, {0, [x: _, y: _, "out-array": [0.0], "x-array": [_ | _], "y-array": [_ | _]]}} =
+    assert {:ok, {0.0, [x: _, y: _, "out-array": [0.0], "x-array": [_ | _], "y-array": [_ | _]]}} =
              Operation.min(im)
   end
 end


### PR DESCRIPTION
**Other changes**
* correct handling of double value
* add experimental image display (intended to be used with patched livebook)
* change spec for header value - do not wrap return values in tuple