### PR TITLE
use correct meta field for n_pages

### DIFF
--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -299,12 +299,15 @@ defmodule Vix.Vips.Image do
     """
     @spec unquote(func_name)(__MODULE__.t()) :: term() | no_return()
     def unquote(func_name)(vips_image) do
-      case header_value(vips_image, unquote(name)) do
+      case header_value(vips_image, normalize_meta(unquote(name))) do
         {:ok, value} -> value
         {:error, error} -> raise to_string(error)
       end
     end
   end
+
+  defp normalize_meta("n_pages"), do: "n-pages"
+  defp normalize_meta(meta), do: meta
 
   defp normalize_string(str) when is_binary(str), do: str
 


### PR DESCRIPTION
This was failing for me and I noted the header field was `n-pages` in my tiffs. Checked the [vips documentation](https://www.libvips.org/API/current/libvips-header.html#VIPS-META-N-PAGES:CAPS) and it turns out it's supposed to be a dash, not an underscore. This corrects that so `Vix.Vips.Image.n_pages/1` works as expected.