### PR TITLE
Rebase kipcole9:matrix_interop

### DIFF
--- a/lib/vix/tensor.ex
+++ b/lib/vix/tensor.ex
@@ -18,14 +18,8 @@ defmodule Vix.Tensor do
     )
   end
 
-  # NOTE: This isn't really the right way to determine
-  # the bit sizes of these types. Is there a way to get
-  # this information from an existing NIF call, or do
-  # we need a call to return format bit sizes?
-
+  # should we support :VIPS_FORMAT_COMPLEX and :VIPS_FORMAT_DPCOMPLEX ?
   defp nx_type(image) do
-    word_size = :erlang.system_info(:wordsize)
-
     case Image.format(image) do
       :VIPS_FORMAT_UCHAR ->
         {:u, 8}
@@ -40,16 +34,16 @@ defmodule Vix.Tensor do
         {:s, 16}
 
       :VIPS_FORMAT_UINT ->
-        {:u, word_size}
+        {:u, 32}
 
       :VIPS_FORMAT_INT ->
-        {:s, word_size}
+        {:s, 32}
 
       :VIPS_FORMAT_FLOAT ->
-        {:u, word_size}
+        {:f, 32}
 
       :VIPS_FORMAT_DOUBLE ->
-        {:u, word_size}
+        {:f, 64}
 
       other ->
         raise ArgumentError, "Cannot convert this image type to binary. Found #{inspect(other)}"

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -380,8 +380,8 @@ defmodule Vix.Vips.Image do
   depending on the caching mechanism and how image is built.
   """
   @spec write_to_tensor(__MODULE__.t()) :: {:ok, Vix.Tensor.t()} | {:error, term()}
-  def write_to_tensor(%Image{ref: vips_image} = image) do
-    with {:ok, binary} <- write_to_binary(vips_image) do
+  def write_to_tensor(%Image{} = image) do
+    with {:ok, binary} <- write_to_binary(image) do
       {:ok, Vix.Tensor.binary_to_tensor(binary, byte_size(binary), image)}
     end
   end

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -165,14 +165,14 @@ defmodule Vix.Vips.ImageTest do
     # same image in raw pixel format
     bin = File.read!(img_path("puppies.raw"))
 
-    {:ok, image} =
-      Image.new_from_binary(
-        bin,
-        Image.width(im),
-        Image.height(im),
-        Image.bands(im),
-        Image.format(im)
-      )
+    assert {:ok, image} =
+             Image.new_from_binary(
+               bin,
+               Image.width(im),
+               Image.height(im),
+               Image.bands(im),
+               Image.format(im)
+             )
 
     out_path = Temp.path!(suffix: ".png", basedir: dir)
     :ok = Image.write_to_file(image, out_path)
@@ -183,11 +183,21 @@ defmodule Vix.Vips.ImageTest do
 
   test "write_to_binary" do
     {:ok, im} = Image.new_from_file(img_path("black.jpg"))
-    {:ok, bin} = Image.write_to_binary(im)
+    assert {:ok, bin} = Image.write_to_binary(im)
 
     expected_bin_size = Image.width(im) * Image.height(im) * Image.bands(im)
 
     assert IO.iodata_length(bin) == expected_bin_size
     assert :binary.copy(<<0>>, expected_bin_size) == bin
+  end
+
+  test "write_to_tensor" do
+    {:ok, im} = Image.new_from_file(img_path("black.jpg"))
+    assert {:ok, %Vix.Tensor{} = tensor} = Image.write_to_tensor(im)
+
+    assert tensor.shape == {Image.width(im), Image.height(im), Image.bands(im)}
+
+    expected_bin_size = Image.width(im) * Image.height(im) * Image.bands(im)
+    assert tensor.data == :binary.copy(<<0>>, expected_bin_size)
   end
 end


### PR DESCRIPTION
See: #43 

* rebased branch and updated to use zero-copy NIF
* update `Vix.Tensor` to return fixed bit-size