### PR TITLE
Add failing test for write_to_stream

### DIFF
--- a/lib/vix/pipe.ex
+++ b/lib/vix/pipe.ex
@@ -35,11 +35,19 @@ defmodule Vix.Pipe do
 
   def read(process, max_size \\ @default_buffer_size)
       when is_integer(max_size) and max_size > 0 do
-    GenServer.call(process, {:read, max_size}, :infinity)
+        IO.puts "Reading"
+    case GenServer.call(process, {:read, max_size}, :infinity) do
+      :eof -> :eof
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> raise ArgumentError, message: reason
+    end
   end
 
   def write(pipe, iodata) do
-    GenServer.call(pipe, {:write, IO.iodata_to_binary(iodata)}, :infinity)
+    case GenServer.call(pipe, {:write, IO.iodata_to_binary(iodata)}, :infinity) do
+      {:error, reason} -> raise ArgumentError, message: reason
+      other -> other
+    end
   end
 
   def error(pipe, reason) do

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -330,7 +330,13 @@ defmodule Vix.Vips.Image do
             {pipe, target} = Pipe.new_vips_target()
             send(parent, {self(), pipe})
 
-            :ok = Nif.nif_image_to_target(vips_image, target, suffix)
+            case Nif.nif_image_to_target(vips_image, target, suffix) do
+              :ok ->
+                :ok
+
+              {:error, reason} ->
+                Pipe.error(pipe, reason)
+            end
           end)
 
         receive do
@@ -343,6 +349,9 @@ defmodule Vix.Vips.Image do
 
         case ret do
           :eof ->
+            {:halt, pipe}
+
+          {:error, _reason} ->
             {:halt, pipe}
 
           {:ok, bin} ->

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -160,6 +160,17 @@ defmodule Vix.Vips.ImageTest do
     assert stat.size > 0 and stat.type == :regular
   end
 
+  test "write_to_stream with invalid suffix", %{dir: dir} do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+
+    out_path = Temp.path!(suffix: ".png", basedir: dir)
+
+    :ok =
+      Image.write_to_stream(im, ".invalid")
+      |> Stream.into(File.stream!(out_path))
+      |> Stream.run()
+  end
+
   test "new_from_binary", %{dir: dir} do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     # same image in raw pixel format


### PR DESCRIPTION
For the happy path, streaming writes are working really well. 

However when there is an error returned from `Vix.Vips.Image.write_to_stream/2`, like when there is an invalid suffix/loader options, then then either:
1. The stream stalls until process timeout or
2. The writer process exists abnormally due to a match error on `:ok = Image.write_to_stream(...)`

Fixing the match error is straight forward.  The key issue is that the process structure isn't resilient to errors on `Image.write_to_stream/2`.  I've tried a number of approaches but each has resulted in subtle race conditions. I've tried trapping exits but I seem unable to get that working as intended too (and I think this is probably the cleanest approach).

I've added a failing test here so you can see and hopefully you have some smarter ideas than I do!!!