### PR TITLE
Add draw_* operations to MutableImage

### DIFF
--- a/lib/vix/vips/flag.ex
+++ b/lib/vix/vips/flag.ex
@@ -21,7 +21,7 @@ defmodule Vix.Vips.FlagHelper do
       quote do
         # Internal module
         @moduledoc false
-        use Bitwise, only_operators: true
+        import Bitwise
         @type t() :: unquote(spec)
 
         alias Vix.Type
@@ -41,7 +41,7 @@ defmodule Vix.Vips.FlagHelper do
         @impl Type
         def to_nif_term(flags, _data) do
           Enum.reduce(flags, 0, fn flag, value ->
-            value ||| to_nif_term(flag)
+            bor(value, to_nif_term(flag))
           end)
         end
 

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -567,7 +567,8 @@ defmodule Vix.Vips.Image do
         :ok ->
           MutableImage.to_image(mut_image)
         {:ok, result} ->
-          {:ok, {MutableImage.to_image(mut_image), result}}
+          {:ok, image} = MutableImage.to_image(mut_image)
+          {:ok, {image, result}}
       end
     after
       MutableImage.stop(mut_image)

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -558,13 +558,17 @@ defmodule Vix.Vips.Image do
   ```
   """
   @spec mutate(__MODULE__.t(), (Vix.Vips.MutableImage.t() -> any())) ::
-          {:ok, __MODULE__.t()} | {:error, term()}
+          {:ok, __MODULE__.t()} | {:ok, {__MODULE__.t(), any()}} | {:error, term()}
   def mutate(%Image{} = image, callback) do
     {:ok, mut_image} = MutableImage.new(image)
 
     try do
-      callback.(mut_image)
-      MutableImage.to_image(mut_image)
+      case callback.(mut_image) do
+        :ok ->
+          MutableImage.to_image(mut_image)
+        {:ok, result} ->
+          {:ok, {MutableImage.to_image(mut_image), result}}
+      end
     after
       MutableImage.stop(mut_image)
     end

--- a/lib/vix/vips/operation.ex
+++ b/lib/vix/vips/operation.ex
@@ -83,7 +83,7 @@ defmodule Vix.Vips.OperationHelper do
   def reject_unsupported_operations(op_name) do
     {_desc, args} = vips_operation_arguments(op_name)
 
-    Enum.any?(args, fn %{flags: flags, value_type: value_type} ->
+    Enum.any?(args, fn %{flags: _flags, value_type: value_type} ->
       # we do not support mutable operations & operations with VipsSource and VipsTarget as arguments
       # :vips_argument_modify in flags ||
         value_type == "VipsSource" ||

--- a/lib/vix/vips/operation.ex
+++ b/lib/vix/vips/operation.ex
@@ -85,7 +85,7 @@ defmodule Vix.Vips.OperationHelper do
 
     Enum.any?(args, fn %{flags: flags, value_type: value_type} ->
       # we do not support mutable operations & operations with VipsSource and VipsTarget as arguments
-      :vips_argument_modify in flags ||
+      # :vips_argument_modify in flags ||
         value_type == "VipsSource" ||
         value_type == "VipsTarget"
     end)


### PR DESCRIPTION
Based upon a request I started working on adding the `draw_*` operations to `MutableImage`. This PR is not ready, but I did want to get your blessing to keep going to flesh out all the functions and add tests. 

I have an experimental `draw` branch of [Image](https://github.com/kipcole9/https://github.com/kipcole9/image/tree/draw) that calls these functions and so far it seems to work very well.  There is a [demo script]( https://github.com/kipcole9/image/blob/draw/bench/add_circles_to_image.exs) that executes in under 500ms to add 1000 circles of a random color and location and uses less than 3Mb of memory.

As always your guidance/corrections most welcome.