### PR TITLE
Add nif_write_bin_to_stdout

### DIFF
--- a/c_src/utils.c
+++ b/c_src/utils.c
@@ -155,3 +155,26 @@ ERL_NIF_TERM to_binary_term(ErlNifEnv *env, void *data, size_t size) {
 
   return bin_term;
 }
+
+ERL_NIF_TERM nif_write_bin_to_stdout(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+  ErlNifBinary binary;
+
+  if (enif_inspect_binary(env, argv[0], &binary)) {
+    char * ptr = (char *)binary.data;
+    const size_t chunk_size = 1024;
+    size_t written = 0;
+
+    while (written != binary.size) {
+        size_t to_write = binary.size - written;
+        if (to_write > chunk_size) to_write = chunk_size;
+        ssize_t bytes_written = write(STDOUT_FILENO, ptr, to_write);
+        if (bytes_written <= 0) {
+            continue;
+        }
+        ptr += bytes_written;
+        written += bytes_written;
+    }
+    return ATOM_OK;
+  }
+  return enif_make_badarg(env);
+}

--- a/c_src/utils.h
+++ b/c_src/utils.h
@@ -111,6 +111,9 @@ ERL_NIF_TERM make_atom(ErlNifEnv *env, const char *name);
 
 ERL_NIF_TERM make_binary(ErlNifEnv *env, const char *str);
 
+ERL_NIF_TERM nif_write_bin_to_stdout(ErlNifEnv *env, int argc,
+                                       const ERL_NIF_TERM argv[]);
+
 bool get_binary(ErlNifEnv *env, ERL_NIF_TERM bin_term, char *str, ssize_t size);
 
 VixResult vix_result(ERL_NIF_TERM term);

--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -142,6 +142,7 @@ static ErlNifFunc nif_funcs[] = {
     /* Syscalls */
     {"nif_pipe_open", 1, nif_pipe_open, 0},
     {"nif_write", 2, nif_write, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"nif_write_bin_to_stdout", 1, nif_write_bin_to_stdout, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"nif_read", 2, nif_read, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"nif_source_new", 0, nif_source_new, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"nif_target_new", 0, nif_target_new, ERL_NIF_DIRTY_JOB_CPU_BOUND}};

--- a/lib/vix/nif.ex
+++ b/lib/vix/nif.ex
@@ -189,4 +189,7 @@ defmodule Vix.Nif do
 
   def nif_target_new,
     do: :erlang.nif_error(:nif_library_not_loaded)
+
+  def nif_write_bin_to_stdout(_string),
+    do: :erlang.nif_error(:nif_library_not_loaded)
 end


### PR DESCRIPTION
Based on the great work done by @cocoa-xu adding [Evision.quicklook/1](https://github.com/cocoa-xu/evision/blob/main/lib/evision_mat.ex#L326-L393) I've added [Image.preview/1](https://github.com/kipcole9/image/blob/main/lib/image.ex#L3502-L3538) that provides the following for iTerm2 terminals:

<img width="853" alt="image" src="https://user-images.githubusercontent.com/15895/196017138-68e824a1-9cdc-4d7e-816e-740092295ab7.png">

However since the iTerm2 preview protocol requires `^G` (decimal 27), and this character is filtered out by `IO.puts` (and `IO.write/1` and the erlang `:io` module functions) there needs to be a way to emit unfiltered binaries.  There is a similar function in `:evision` from which I borrowed liberally. But for `Image`, `:vix` is a hard dependency whereas `:evision` is optional.

Therefore this PR adds `Vix.Nif.nif_write_bin_to_stdout/1` in order to accomplish just that.

BTW, If you think `Image.preview/1` is better placed in `Vix` then please copy whatever you think is useful.
