### PR TITLE
Update the Access behaviour to support slices

### DIFF
--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -234,10 +234,7 @@ defmodule Vix.Vips.Image do
   end
 
   defp single_step_range?(%Range{} = range) do
-    cond do
-      Map.get(range, :step) == 1 -> true
-      Map.has_key?(range, :step) -> false
-    end
+    Map.get(range, :step) == 1 || !Map.has_key?(range, :step)
   end
 
   defp extract_area(image, left, top, width, height) do

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -193,8 +193,9 @@ defmodule Vix.Vips.Image do
 
   def fetch_range(image, %Range{first: first, last: last}) when last < 0 and first < last do
     bands = bands(image)
+    last = bands + last
 
-    if (last = bands + last) > 0 do
+    if last > 0 do
       fetch(image, (bands + first)..last)
     else
       raise ArgumentError, "Resolved invalid range #{(bands + first)..last}"

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -169,9 +169,8 @@ defmodule Vix.Vips.Image do
     with {:ok, left, width} <- validate_dimension(width, width(image)),
          {:ok, top, height} <- validate_dimension(height, height(image)),
          {:ok, first_band, bands} <- validate_dimension(bands, bands(image)),
-         {:ok, area} <- extract_area(image, left, top, width, height),
-         {:ok, slice} <- extract_band(area, first_band, n: bands) do
-      {:ok, slice}
+         {:ok, area} <- extract_area(image, left, top, width, height) do
+      extract_band(area, first_band, n: bands)
     end
   end
 

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -120,7 +120,7 @@ defmodule Vix.Vips.Image do
   def fetch(image, band) when is_integer(band) and band >= 0 do
     case Vix.Vips.Operation.extract_band(image, band) do
       {:ok, band} -> {:ok, band}
-      {:error, _reason} -> raise ArgumentError, "Invalid band requested. Found #{inspect band}"
+      {:error, _reason} -> raise ArgumentError, "Invalid band requested. Found #{inspect(band)}"
     end
   end
 
@@ -128,7 +128,7 @@ defmodule Vix.Vips.Image do
   def fetch(image, band) when is_integer(band) and band < 0 do
     case bands(image) + band do
       band when band >= 0 -> fetch(image, band)
-      _other -> raise ArgumentError, "Invalid band requested. Found #{inspect band}"
+      _other -> raise ArgumentError, "Invalid band requested. Found #{inspect(band)}"
     end
   end
 
@@ -136,7 +136,7 @@ defmodule Vix.Vips.Image do
     if single_step_range?(range) do
       fetch_range(image, range)
     else
-      raise ArgumentError, "Range arguments must have a step of 1. Found #{inspect range}"
+      raise ArgumentError, "Range arguments must have a step of 1. Found #{inspect(range)}"
     end
   end
 
@@ -180,7 +180,7 @@ defmodule Vix.Vips.Image do
   def fetch_range(image, %Range{first: first, last: last}) when first >= 0 and last >= first do
     case Vix.Vips.Operation.extract_band(image, first, n: last - first + 1) do
       {:ok, band} -> {:ok, band}
-      {:error, _reason} -> raise "Invalid band range #{inspect first..last}"
+      {:error, _reason} -> raise "Invalid band range #{inspect(first..last)}"
     end
   end
 
@@ -193,6 +193,7 @@ defmodule Vix.Vips.Image do
 
   def fetch_range(image, %Range{first: first, last: last}) when last < 0 and first < last do
     bands = bands(image)
+
     if (last = bands + last) > 0 do
       fetch(image, (bands + first)..last)
     else
@@ -201,7 +202,7 @@ defmodule Vix.Vips.Image do
   end
 
   def fetch_range(_image, %Range{} = range) do
-    raise ArgumentError, "Invalid range #{inspect range}"
+    raise ArgumentError, "Invalid range #{inspect(range)}"
   end
 
   # For integer dimensions treat is as the number of pixels
@@ -214,12 +215,13 @@ defmodule Vix.Vips.Image do
     if single_step_range?(range) do
       validate_range_dimension(range, width)
     else
-      raise ArgumentError, "Range arguments must have a step of 1. Found #{inspect range}"
+      raise ArgumentError, "Range arguments must have a step of 1. Found #{inspect(range)}"
     end
   end
 
   defp validate_dimension(dim, width) do
-    raise ArgumentError, "Invalid dimension #{inspect dim}. Dimension must be between 0 and #{inspect width - 1}"
+    raise ArgumentError,
+          "Invalid dimension #{inspect(dim)}. Dimension must be between 0 and #{inspect(width - 1)}"
   end
 
   # For positive ranges start from the left and top
@@ -241,7 +243,7 @@ defmodule Vix.Vips.Image do
   end
 
   defp validate_range_dimension(range, _width) do
-    raise ArgumentError, "Invalid range #{inspect range}"
+    raise ArgumentError, "Invalid range #{inspect(range)}"
   end
 
   # We can do this as a guard in later Elixir versions but

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -233,8 +233,12 @@ defmodule Vix.Vips.Image do
     :error
   end
 
-  defp single_step_range?(%Range{step: 1}), do: true
-  defp single_step_range?(range), do: !Map.has_key?(range, :step)
+  defp single_step_range?(%Range{} = range) do
+    cond do
+      Map.get(range, :step) == 1 -> true
+      Map.has_key?(range, :step) -> false
+    end
+  end
 
   defp extract_area(image, left, top, width, height) do
     case Operation.extract_area(image, left, top, width, height) do

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -203,13 +203,13 @@ defmodule Vix.Vips.Image do
   # For negative ranges start from the right and bottom
   defp validate_dimension(%{first: first, last: last, step: 1}, width)
        when first < 0 and last < 0 and last > first and abs(first) < width do
-    {:ok, width + first, (width + last) - (width + first) + 1}
+    {:ok, width + first, width + last - (width + first) + 1}
   end
 
   # Positive start to a negative end
   defp validate_dimension(%{first: first, last: last, step: 1}, width)
        when first >= 0 and last < 0 and abs(last) <= width do
-    {:ok, first, (width + last) - first + 1}
+    {:ok, first, width + last - first + 1}
   end
 
   defp validate_dimension(_dim, _width) do
@@ -229,7 +229,6 @@ defmodule Vix.Vips.Image do
       _other -> :error
     end
   end
-
 
   @doc """
   Opens `path` for reading, returns an instance of `t:Vix.Vips.Image.t/0`

--- a/test/support/images.ex
+++ b/test/support/images.ex
@@ -2,6 +2,7 @@ defmodule Vix.Support.Images do
   @moduledoc false
 
   import ExUnit.Assertions
+  alias Vix.Vips.Image
 
   @images_path Path.join(__DIR__, "../images")
 
@@ -22,5 +23,9 @@ defmodule Vix.Support.Images do
       {:error, reason} ->
         flunk("Failed to compare images, error: #{inspect(reason)}")
     end
+  end
+
+  def shape(image) do
+    {Image.width(image), Image.height(image), Image.bands(image)}
   end
 end

--- a/test/support/images.ex
+++ b/test/support/images.ex
@@ -28,4 +28,8 @@ defmodule Vix.Support.Images do
   def shape(image) do
     {Image.width(image), Image.height(image), Image.bands(image)}
   end
+
+  def range_has_step do
+    Map.has_key?(1..2, :step)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+unless Map.has_key?(1..2, :step), do: ExUnit.configure(exclude: [:range_with_step])
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
-unless Map.has_key?(1..2, :step), do: ExUnit.configure(exclude: [:range_with_step])
 ExUnit.start()

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -23,4 +23,40 @@ defmodule Vix.Vips.AccessTest do
     assert im[1..5] == nil
     assert im[-5..-1] == nil
   end
+
+  test "Access behaviour for Vix.Vipx.Image with slicing" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    assert shape(im[[:all, :all]]) == shape(im)
+    assert shape(im[[:all, :all, :all]]) == shape(im)
+    assert shape(im[[0..2, :all, :all]]) == {3, 389, 3}
+    assert shape(im[[0..2, 0..2, 0..1]]) == {3, 3, 2}
+  end
+
+  test "Access behaviour for Vix.Vipx.Image with slicing and negative ranges" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    assert shape(im[[-3..-1, :all, :all]]) == {3, 389, 3}
+    assert shape(im[[-3..-1, -3..-1, -2..-1]]) == {3, 3, 2}
+  end
+
+  test "Access behaviour for Vix.Vipx.Image with slicing and mixed positive/negative ranges" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    assert shape(im[[0..-1//1, :all, :all]]) == {518, 389, 3}
+    assert shape(im[[0..-1//1, 1..-1//1, -2..-1//1]]) == {518, 388, 2}
+  end
+
+  test "Access behaviour with invalid dimensions" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+
+    # Negative indicies can't include 0 since thats a wrap-around
+    assert im[[-3..0, :all, :all]] == nil
+
+    # Index larger than the image
+    assert im[[0..1_000, :all, :all]] == nil
+
+    # Index not increasing
+    assert im[[0..-3, :all, :all]] == nil
+
+    # Step != 1
+    assert im[[0..-3//2, :all, :all]] == nil
+  end
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -38,6 +38,7 @@ defmodule Vix.Vips.AccessTest do
     assert shape(im[[-3..-1, -3..-1, -2..-1]]) == {3, 3, 2}
   end
 
+  @tag :range_with_step
   test "Access behaviour for Vix.Vipx.Image with slicing and mixed positive/negative ranges" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert shape(im[[0..-1//1, :all, :all]]) == {518, 389, 3}
@@ -55,6 +56,11 @@ defmodule Vix.Vips.AccessTest do
 
     # Index not increasing
     assert im[[0..-3, :all, :all]] == nil
+  end
+
+  @tag :range_with_step
+  test "Access behaviour with invalid dimensions and invalid step" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
     # Step != 1
     assert im[[0..-3//2, :all, :all]] == nil

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -38,11 +38,19 @@ defmodule Vix.Vips.AccessTest do
     assert shape(im[[-3..-1, -3..-1, -2..-1]]) == {3, 3, 2}
   end
 
-  @tag :range_with_step
-  test "Access behaviour for Vix.Vipx.Image with slicing and mixed positive/negative ranges" do
-    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-    assert shape(im[[0..-1//1, :all, :all]]) == {518, 389, 3}
-    assert shape(im[[0..-1//1, 1..-1//1, -2..-1//1]]) == {518, 388, 2}
+  if range_has_step() do
+    test "Access behaviour for Vix.Vipx.Image with slicing and mixed positive/negative ranges" do
+      {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+      assert shape(im[[0..-1//1, :all, :all]]) == {518, 389, 3}
+      assert shape(im[[0..-1//1, 1..-1//1, -2..-1//1]]) == {518, 388, 2}
+    end
+
+    test "Access behaviour with invalid dimensions and invalid step" do
+      {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+
+      # Step != 1
+      assert im[[0..-3//2, :all, :all]] == nil
+    end
   end
 
   test "Access behaviour with invalid dimensions" do
@@ -58,11 +66,4 @@ defmodule Vix.Vips.AccessTest do
     assert im[[0..-3, :all, :all]] == nil
   end
 
-  @tag :range_with_step
-  test "Access behaviour with invalid dimensions and invalid step" do
-    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-
-    # Step != 1
-    assert im[[0..-3//2, :all, :all]] == nil
-  end
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -15,13 +15,22 @@ defmodule Vix.Vips.AccessTest do
 
   test "Access behaviour for Vix.Vips.Image with invalid integer band" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-    assert im[5] == nil
+
+    assert_raise ArgumentError, "Invalid band requested. Found 5", fn ->
+      im[5]
+    end
   end
 
   test "Access behaviour for Vix.Vips.Image with invalid range band" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-    assert im[1..5] == nil
-    assert im[-5..-1] == nil
+
+    assert_raise RuntimeError, "Invalid band range 1..5", fn ->
+      im[1..5]
+    end
+
+    assert_raise ArgumentError, "Invalid range -2..2", fn ->
+      im[-5..-1]
+    end
   end
 
   test "Access behaviour for Vix.Vips.Image with slicing" do
@@ -42,10 +51,14 @@ defmodule Vix.Vips.AccessTest do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
     # Negative indicies can't include 0 since thats a wrap-around
-    assert im[[-3..0, :all, :all]] == nil
+    assert_raise ArgumentError, "Invalid range -3..0", fn ->
+      im[[-3..0, :all, :all]]
+    end
 
     # Index larger than the image
-    assert im[[0..1_000, :all, :all]] == nil
+    assert_raise ArgumentError, "Invalid range 0..1000", fn ->
+      im[[0..1_000, :all, :all]]
+    end
   end
 
   # We can't use the 1..3//1 syntax since it fails on older
@@ -65,14 +78,18 @@ defmodule Vix.Vips.AccessTest do
       {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
       # Step != 1
-      assert im[[Map.put(0..-3, :step, 2), :all, :all]] == nil
+      assert_raise ArgumentError, "Range arguments must have a step of 1. Found 0..-3//2", fn ->
+        im[[Map.put(0..-3, :step, 2), :all, :all]]
+      end
     end
 
     test "Access behaviour with invalid dimensions when ranges have steps" do
       {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
       # Index not increasing
-      assert im[[0..-3, :all, :all]] == nil
+      assert_raise ArgumentError, "Range arguments must have a step of 1. Found 0..-3//-1", fn ->
+        im[[0..-3, :all, :all]]
+      end
     end
   end
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -65,5 +65,4 @@ defmodule Vix.Vips.AccessTest do
     # Index not increasing
     assert im[[0..-3, :all, :all]] == nil
   end
-
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -3,28 +3,28 @@ defmodule Vix.Vips.AccessTest do
   import Vix.Support.Images
   alias Vix.Vips.Image
 
-  test "Access behaviour for Vix.Vipx.Image for an integer" do
+  test "Access behaviour for Vix.Vips.Image for an integer retrieves a band" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert im[1]
   end
 
-  test "Access behaviour for Vix.Vipx.Image for a range" do
+  test "Access behaviour for Vix.Vips.Image for a range retrieves a range of bands" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert im[1..2]
   end
 
-  test "Access behaviour for Vix.Vipx.Image with invalid integer band" do
+  test "Access behaviour for Vix.Vips.Image with invalid integer band" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert im[5] == nil
   end
 
-  test "Access behaviour for Vix.Vipx.Image with invalid range band" do
+  test "Access behaviour for Vix.Vips.Image with invalid range band" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert im[1..5] == nil
     assert im[-5..-1] == nil
   end
 
-  test "Access behaviour for Vix.Vipx.Image with slicing" do
+  test "Access behaviour for Vix.Vips.Image with slicing" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert shape(im[[:all, :all]]) == shape(im)
     assert shape(im[[:all, :all, :all]]) == shape(im)
@@ -32,20 +32,33 @@ defmodule Vix.Vips.AccessTest do
     assert shape(im[[0..2, 0..2, 0..1]]) == {3, 3, 2}
   end
 
-  test "Access behaviour for Vix.Vipx.Image with slicing and negative ranges" do
+  test "Access behaviour for Vix.Vips.Image with slicing and negative ranges" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert shape(im[[-3..-1, :all, :all]]) == {3, 389, 3}
     assert shape(im[[-3..-1, -3..-1, -2..-1]]) == {3, 3, 2}
   end
 
+  test "Access behaviour with invalid dimensions" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+
+    # Negative indicies can't include 0 since thats a wrap-around
+    assert im[[-3..0, :all, :all]] == nil
+
+    # Index larger than the image
+    assert im[[0..1_000, :all, :all]] == nil
+  end
+
+  # We can't use the 1..3//1 syntax since it fails on older
+  # Elixir. So we detect when the `Range.t` has a `:step` and then
+  # use Map.put/3 to place the expected value
+
   if range_has_step() do
-    test "Access behaviour for Vix.Vipx.Image with slicing and mixed positive/negative ranges" do
+    test "Access behaviour for Vix.Vips.Image with slicing and mixed positive/negative ranges" do
       {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
       assert shape(im[[Map.put(0..-1, :step, 1), :all, :all]]) == {518, 389, 3}
 
-      assert shape(
-               im[[Map.put(0..-1, :step, 1), Map.put(1..-1, :step, 1), Map.put(-2..-1, :step, 1)]]
-             ) == {518, 388, 2}
+      im = im[[Map.put(0..-1, :step, 1), Map.put(1..-1, :step, 1), Map.put(-2..-1, :step, 1)]]
+      assert shape(im) == {518, 388, 2}
     end
 
     test "Access behaviour with invalid dimensions and invalid step" do
@@ -63,13 +76,4 @@ defmodule Vix.Vips.AccessTest do
     end
   end
 
-  test "Access behaviour with invalid dimensions" do
-    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-
-    # Negative indicies can't include 0 since thats a wrap-around
-    assert im[[-3..0, :all, :all]] == nil
-
-    # Index larger than the image
-    assert im[[0..1_000, :all, :all]] == nil
-  end
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -41,15 +41,18 @@ defmodule Vix.Vips.AccessTest do
   if range_has_step() do
     test "Access behaviour for Vix.Vipx.Image with slicing and mixed positive/negative ranges" do
       {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
-      assert shape(im[[0..-1//1, :all, :all]]) == {518, 389, 3}
-      assert shape(im[[0..-1//1, 1..-1//1, -2..-1//1]]) == {518, 388, 2}
+      assert shape(im[[Map.put(0..-1, :step, 1), :all, :all]]) == {518, 389, 3}
+
+      assert shape(
+               im[[Map.put(0..-1, :step, 1), Map.put(1..-1, :step, 1), Map.put(-2..-1, :step, 1)]]
+             ) == {518, 388, 2}
     end
 
     test "Access behaviour with invalid dimensions and invalid step" do
       {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
       # Step != 1
-      assert im[[0..-3//2, :all, :all]] == nil
+      assert im[[Map.put(0..-3, :step, 2), :all, :all]] == nil
     end
   end
 

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -75,5 +75,4 @@ defmodule Vix.Vips.AccessTest do
       assert im[[0..-3, :all, :all]] == nil
     end
   end
-
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -54,6 +54,13 @@ defmodule Vix.Vips.AccessTest do
       # Step != 1
       assert im[[Map.put(0..-3, :step, 2), :all, :all]] == nil
     end
+
+    test "Access behaviour with invalid dimensions when ranges have steps" do
+      {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+
+      # Index not increasing
+      assert im[[0..-3, :all, :all]] == nil
+    end
   end
 
   test "Access behaviour with invalid dimensions" do
@@ -64,8 +71,5 @@ defmodule Vix.Vips.AccessTest do
 
     # Index larger than the image
     assert im[[0..1_000, :all, :all]] == nil
-
-    # Index not increasing
-    assert im[[0..-3, :all, :all]] == nil
   end
 end


### PR DESCRIPTION
The PR updates the Access behaviour for images to allow slices in a manner similar to Nx. See the documentation in the `Vix.Vips.Image` module and the tests in the `access_test.exs` files.