### PR TITLE
Add MutableImage attribute access

### DIFF
--- a/lib/vix/vips/mutable_image.ex
+++ b/lib/vix/vips/mutable_image.ex
@@ -56,6 +56,43 @@ defmodule Vix.Vips.MutableImage do
   end
 
   @doc """
+  Return the number of bands of a mutable image.
+  """
+  def bands(%MutableImage{pid: pid}) do
+    GenServer.call(pid, :bands)
+  end
+
+  @doc """
+  Return the width of a mutable image.
+  """
+  def width(%MutableImage{pid: pid}) do
+    GenServer.call(pid, :width)
+  end
+
+  @doc """
+  Return the height of a mutable image.
+  """
+  def height(%MutableImage{pid: pid}) do
+    GenServer.call(pid, :height)
+  end
+
+  @doc """
+  Return a boolean indicating if a mutable image
+  has an alpha band.
+  """
+  def has_alpha?(%MutableImage{pid: pid}) do
+    GenServer.call(pid, :has_alpha?)
+  end
+
+  @doc """
+  Return the shape of the umage as
+  `{width, height, bands}`.
+  """
+  def shape(%MutableImage{pid: pid}) do
+    GenServer.call(pid, :shape)
+  end
+
+  @doc """
   Set the value of existing metadata item on an image. Value is converted to match existing value GType
   """
   @spec update(__MODULE__.t(), String.t(), term()) :: :ok | {:error, term()}
@@ -146,6 +183,35 @@ defmodule Vix.Vips.MutableImage do
   @impl true
   def handle_call({:operation, callback}, _from, %{image: image} = state) do
     {:reply, callback.(image), state}
+  end
+
+  @impl true
+  def handle_call(:width, _from, %{image: image} = state) do
+    {:reply, {:ok, Image.width(image)}, state}
+  end
+
+  @impl true
+  def handle_call(:height, _from, %{image: image} = state) do
+    {:reply, {:ok, Image.height(image)}, state}
+  end
+
+  @impl true
+  def handle_call(:bands, _from, %{image: image} = state) do
+    {:reply, {:ok, Image.bands(image)}, state}
+  end
+
+  @impl true
+  def handle_call(:has_alpha?, _from, %{image: image} = state) do
+    {:reply, {:ok, Image.has_alpha?(image)}, state}
+  end
+
+  @impl true
+  def handle_call(:shape, _from, %{image: image} = state) do
+    width = Image.width(image)
+    height = Image.height(image)
+    bands = Image.bands(image)
+
+    {:reply, {:ok, {width, height, bands}}, state}
   end
 
   defp wrap_type({:ok, pid}), do: {:ok, %MutableImage{pid: pid}}

--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -51,4 +51,14 @@ defmodule Vix.Vips.MutableImageTest do
 
     assert {:ok, 0} == Image.header_value(new_img, "orientation")
   end
+
+  test "introspection" do
+    {:ok, i} = Vix.Vips.Image.new_from_file(img_path("puppies.jpg"))
+
+    assert {:ok, {_, 518}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.width(m) end)
+    assert {:ok, {_, 389}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.height(m) end)
+    assert {:ok, {_, 3}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.bands(m) end)
+    assert {:ok, {_, false}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.has_alpha?(m) end)
+
+  end
 end

--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -58,7 +58,8 @@ defmodule Vix.Vips.MutableImageTest do
     assert {:ok, {_, 518}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.width(m) end)
     assert {:ok, {_, 389}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.height(m) end)
     assert {:ok, {_, 3}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.bands(m) end)
-    assert {:ok, {_, false}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.has_alpha?(m) end)
 
+    assert {:ok, {_, false}} =
+             Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.has_alpha?(m) end)
   end
 end


### PR DESCRIPTION
Adds:
* MutableImage.width/1
* MutableImage.height/1
* MutableImage.bands/1
* MutableImage.has_alpha?/1

When applying the `draw` operations, some of the parameters - like the color - may depend on the number of bands in the image and whether the image has an alpha band. Hence the addition of just the basic image attribute functions for a mutable image.