### PR TITLE
Reorder tabs in Kino to show image preview first

### DIFF
--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -911,7 +911,7 @@ defmodule Vix.Vips.Image do
         attributes = attributes_from_image(image)
         {:ok, encoded} = Vix.Vips.Image.write_to_buffer(image, ".png")
         image = Kino.Image.new(encoded, :png)
-        tabs = Kino.Layout.tabs(Attributes: attributes, Image: image)
+        tabs = Kino.Layout.tabs(Image: image, Attributes: attributes)
         Kino.Render.to_livebook(tabs)
       end
 
@@ -924,7 +924,6 @@ defmodule Vix.Vips.Image do
             {"Interpretation", Vix.Vips.Image.interpretation(image)},
             {"Format", Vix.Vips.Image.format(image)},
             {"Filename", Vix.Vips.Image.filename(image)},
-            {"Orientation", Vix.Vips.Image.orientation(image)},
             {"Has alpha band?", Vix.Vips.Image.has_alpha?(image)}
           ]
           |> Enum.map(fn {k, v} -> [{"Attribute", k}, {"Value", v}] end)

--- a/test/vix/vips/livebook_render_test.exs
+++ b/test/vix/vips/livebook_render_test.exs
@@ -11,23 +11,18 @@ if Code.ensure_loaded?(Kino.Render) do
 
       assert {:ok, %Image{ref: _ref} = image} = Image.new_from_file(img_path("puppies.jpg"))
 
-      assert {:tabs,
-              [
-                {:js,
-                 %{
-                   export: nil,
-                   js_view: %{
-                     assets: %{
-                       archive_path: _,
-                       hash: _,
-                       js_path: "main.js"
-                     },
-                     pid: _,
-                     ref: _
-                   }
-                 }},
-                {:image, _, "image/png"}
-              ], %{labels: ["Attributes", "Image"]}} = Kino.Render.to_livebook(image)
+      assert {
+               :tabs,
+               [
+                 {:image, _, "image/png"},
+                 {:js,
+                  %{
+                    export: nil,
+                    js_view: %{assets: %{archive_path: _, hash: _, js_path: "main.js"}, pid: _}
+                  }}
+               ],
+               %{labels: ["Image", "Attributes"]}
+             } = Kino.Render.to_livebook(image)
     end
   end
 end


### PR DESCRIPTION
This PR makes some simple changes to the Kino behaviour to reflect better user expectations (image is shown by default).

* Reorder tabs in Kino to show image preview first
* Remove orientation from image metadata shown in Kino since that header field is not always present and its integer representation is not easily understood.