### PR TITLE
Feat: Support `~/..` paths for VIPS.Image.Image.write_to_file

### DIFF
--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -610,7 +610,7 @@ defmodule Vix.Vips.Image do
   """
   @spec write_to_file(__MODULE__.t(), String.t()) :: :ok | {:error, term()}
   def write_to_file(%Image{ref: vips_image}, path) do
-    Nif.nif_image_write_to_file(vips_image, normalize_string(path))
+    Nif.nif_image_write_to_file(vips_image, normalize_string(Path.expand(path)))
   end
 
   @doc """


### PR DESCRIPTION
Problem: 
- currently path expansion works for the `new_from_file` function, but does not for `write_to_file`

Solution: 
- for symmetry also add path expansion for the `write_to_file` function


Working sample: 
```
{:ok, img} = Image.new_from_file("~/Desktop/kitten.jpg")
hscale = 400 / Image.width(img)
{:ok, resized_img} = Operation.resize(img, hscale)
:ok = Image.write_to_file(resized_img, "~/Desktop/kitten-400x.jpg")
```