### PR TITLE
MutableImage.bands/1, width/1, height/1, has_alpha?/1 return simple value

### DIFF
--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -769,12 +769,16 @@ defmodule Vix.Vips.Image do
 
     try do
       case callback.(mut_image) do
-        :ok ->
-          MutableImage.to_image(mut_image)
-
         {:ok, result} ->
           {:ok, image} = MutableImage.to_image(mut_image)
           {:ok, {image, result}}
+          
+        :ok ->
+          MutableImage.to_image(mut_image)
+            
+        # For width, height, bands, has_alpha?
+        result ->
+          result
       end
     after
       MutableImage.stop(mut_image)

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -772,10 +772,10 @@ defmodule Vix.Vips.Image do
         {:ok, result} ->
           {:ok, image} = MutableImage.to_image(mut_image)
           {:ok, {image, result}}
-          
+
         :ok ->
           MutableImage.to_image(mut_image)
-            
+
         # For width, height, bands, has_alpha?
         result ->
           result

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -915,7 +915,7 @@ defmodule Vix.Vips.Image do
         attributes = attributes_from_image(image)
         {:ok, encoded} = Vix.Vips.Image.write_to_buffer(image, ".png")
         image = Kino.Image.new(encoded, :png)
-        tabs = Kino.Layout.tabs(Image: image, Attributes: attributes)
+        tabs = Kino.Layout.tabs(Attributes: attributes, Image: image)
         Kino.Render.to_livebook(tabs)
       end
 
@@ -928,6 +928,7 @@ defmodule Vix.Vips.Image do
             {"Interpretation", Vix.Vips.Image.interpretation(image)},
             {"Format", Vix.Vips.Image.format(image)},
             {"Filename", Vix.Vips.Image.filename(image)},
+            {"Orientation", Vix.Vips.Image.orientation(image)},
             {"Has alpha band?", Vix.Vips.Image.has_alpha?(image)}
           ]
           |> Enum.map(fn {k, v} -> [{"Attribute", k}, {"Value", v}] end)

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -911,7 +911,7 @@ defmodule Vix.Vips.Image do
         attributes = attributes_from_image(image)
         {:ok, encoded} = Vix.Vips.Image.write_to_buffer(image, ".png")
         image = Kino.Image.new(encoded, :png)
-        tabs = Kino.Layout.tabs(Attributes: attributes, Image: image)
+        tabs = Kino.Layout.tabs(Image: image, Attributes: attributes)
         Kino.Render.to_livebook(tabs)
       end
 
@@ -924,7 +924,6 @@ defmodule Vix.Vips.Image do
             {"Interpretation", Vix.Vips.Image.interpretation(image)},
             {"Format", Vix.Vips.Image.format(image)},
             {"Filename", Vix.Vips.Image.filename(image)},
-            {"Orientation", Vix.Vips.Image.orientation(image)},
             {"Has alpha band?", Vix.Vips.Image.has_alpha?(image)}
           ]
           |> Enum.map(fn {k, v} -> [{"Attribute", k}, {"Value", v}] end)

--- a/lib/vix/vips/mutable_image.ex
+++ b/lib/vix/vips/mutable_image.ex
@@ -58,6 +58,7 @@ defmodule Vix.Vips.MutableImage do
   @doc """
   Return the number of bands of a mutable image.
   """
+  @spec bands(t()) :: pos_integer()
   def bands(%MutableImage{pid: pid}) do
     GenServer.call(pid, :bands)
   end
@@ -65,6 +66,7 @@ defmodule Vix.Vips.MutableImage do
   @doc """
   Return the width of a mutable image.
   """
+  @spec width(t()) :: pos_integer()
   def width(%MutableImage{pid: pid}) do
     GenServer.call(pid, :width)
   end
@@ -72,6 +74,7 @@ defmodule Vix.Vips.MutableImage do
   @doc """
   Return the height of a mutable image.
   """
+  @spec height(t()) :: pos_integer()
   def height(%MutableImage{pid: pid}) do
     GenServer.call(pid, :height)
   end
@@ -80,6 +83,7 @@ defmodule Vix.Vips.MutableImage do
   Return a boolean indicating if a mutable image
   has an alpha band.
   """
+  @spec has_alpha?(t()) :: boolean
   def has_alpha?(%MutableImage{pid: pid}) do
     GenServer.call(pid, :has_alpha?)
   end
@@ -187,22 +191,22 @@ defmodule Vix.Vips.MutableImage do
 
   @impl true
   def handle_call(:width, _from, %{image: image} = state) do
-    {:reply, {:ok, Image.width(image)}, state}
+    {:reply, Image.width(image), state}
   end
 
   @impl true
   def handle_call(:height, _from, %{image: image} = state) do
-    {:reply, {:ok, Image.height(image)}, state}
+    {:reply, Image.height(image), state}
   end
 
   @impl true
   def handle_call(:bands, _from, %{image: image} = state) do
-    {:reply, {:ok, Image.bands(image)}, state}
+    {:reply, Image.bands(image), state}
   end
 
   @impl true
   def handle_call(:has_alpha?, _from, %{image: image} = state) do
-    {:reply, {:ok, Image.has_alpha?(image)}, state}
+    {:reply, Image.has_alpha?(image), state}
   end
 
   @impl true
@@ -211,7 +215,7 @@ defmodule Vix.Vips.MutableImage do
     height = Image.height(image)
     bands = Image.bands(image)
 
-    {:reply, {:ok, {width, height, bands}}, state}
+    {:reply, {width, height, bands}, state}
   end
 
   defp wrap_type({:ok, pid}), do: {:ok, %MutableImage{pid: pid}}

--- a/test/vix/vips/livebook_render_test.exs
+++ b/test/vix/vips/livebook_render_test.exs
@@ -11,18 +11,23 @@ if Code.ensure_loaded?(Kino.Render) do
 
       assert {:ok, %Image{ref: _ref} = image} = Image.new_from_file(img_path("puppies.jpg"))
 
-      assert {
-               :tabs,
-               [
-                 {:image, _, "image/png"},
-                 {:js,
-                  %{
-                    export: nil,
-                    js_view: %{assets: %{archive_path: _, hash: _, js_path: "main.js"}, pid: _}
-                  }}
-               ],
-               %{labels: ["Image", "Attributes"]}
-             } = Kino.Render.to_livebook(image)
+      assert {:tabs,
+              [
+                {:js,
+                 %{
+                   export: nil,
+                   js_view: %{
+                     assets: %{
+                       archive_path: _,
+                       hash: _,
+                       js_path: "main.js"
+                     },
+                     pid: _,
+                     ref: _
+                   }
+                 }},
+                {:image, _, "image/png"}
+              ], %{labels: ["Attributes", "Image"]}} = Kino.Render.to_livebook(image)
     end
   end
 end

--- a/test/vix/vips/livebook_render_test.exs
+++ b/test/vix/vips/livebook_render_test.exs
@@ -11,23 +11,18 @@ if Code.ensure_loaded?(Kino.Render) do
 
       assert {:ok, %Image{ref: _ref} = image} = Image.new_from_file(img_path("puppies.jpg"))
 
-      assert {:tabs,
-              [
-                {:js,
-                 %{
-                   export: nil,
-                   js_view: %{
-                     assets: %{
-                       archive_path: _,
-                       hash: _,
-                       js_path: "main.js"
-                     },
-                     pid: _,
-                     ref: _
-                   }
-                 }},
-                {:image, _, "image/png"}
-              ], %{labels: ["Attributes", "Image"]}} = Kino.Render.to_livebook(image)
+      assert {
+               :tabs,
+               [
+                 {:image, _, "image/png"},
+                 {:js,
+                  %{
+                    export: nil,
+                    js_view: %{assets: %{archive_path: _, hash: _, js_path: "main.js"}, pid: _}
+                  }}
+               ],
+               %{labels: ["Image", "Attributes"]}
+             } = Kino.Render.to_livebook(image)
     end
   end
 end

--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -54,12 +54,9 @@ defmodule Vix.Vips.MutableImageTest do
 
   test "introspection" do
     {:ok, i} = Vix.Vips.Image.new_from_file(img_path("puppies.jpg"))
-
-    assert {:ok, {_, 518}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.width(m) end)
-    assert {:ok, {_, 389}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.height(m) end)
-    assert {:ok, {_, 3}} = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.bands(m) end)
-
-    assert {:ok, {_, false}} =
-             Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.has_alpha?(m) end)
+    assert 518 = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.width(m) end)
+    assert 389 = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.height(m) end)
+    assert 3 = Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.bands(m) end)
+    assert false == Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.has_alpha?(m) end)
   end
 end


### PR DESCRIPTION
Currently these functions return `{:ok, value}` but the `Vix.Vips.Image` versions just return `value`. This PR brings the `MutableImage` versions into line with the `Image` versions.  Also added specs for those functions.