### PR TITLE
Change additional output type & skip empty optional arguments

### DIFF
--- a/lib/vix/vips/mutable_operation.ex
+++ b/lib/vix/vips/mutable_operation.ex
@@ -50,19 +50,38 @@ defmodule Vix.Vips.MutableOperation do
     #{prepare_doc(desc, in_req_spec, in_opt_spec, out_req_spec, out_opt_spec)}
     """
     @spec unquote(func_typespec(func_name, in_req_spec, in_opt_spec, out_req_spec, out_opt_spec))
-    def unquote(func_name)(unquote_splicing(req_params), optional \\ []) do
-      [mutable_image | rest_params] = unquote(req_params)
+    if in_opt_spec == [] do
+      # operations without optional arguments
+      def unquote(func_name)(unquote_splicing(req_params)) do
+        [mutable_image | rest_params] = unquote(req_params)
 
-      operation_cb = fn image ->
-        operation_call(
-          unquote(name),
-          [image | rest_params],
-          optional,
-          unquote(Macro.escape(spec))
-        )
+        operation_cb = fn image ->
+          operation_call(
+            unquote(name),
+            [image | rest_params],
+            [],
+            unquote(Macro.escape(spec))
+          )
+        end
+
+        GenServer.call(mutable_image.pid, {:operation, operation_cb})
       end
+    else
+      # operations with optional arguments
+      def unquote(func_name)(unquote_splicing(req_params), optional \\ []) do
+        [mutable_image | rest_params] = unquote(req_params)
 
-      GenServer.call(mutable_image.pid, {:operation, operation_cb})
+        operation_cb = fn image ->
+          operation_call(
+            unquote(name),
+            [image | rest_params],
+            optional,
+            unquote(Macro.escape(spec))
+          )
+        end
+
+        GenServer.call(mutable_image.pid, {:operation, operation_cb})
+      end
     end
 
     bang_func_name = function_name(String.to_atom(name <> "!"))
@@ -79,12 +98,25 @@ defmodule Vix.Vips.MutableOperation do
               out_opt_spec
             )
           )
-    def unquote(bang_func_name)(unquote_splicing(req_params), optional \\ []) do
-      case __MODULE__.unquote(func_name)(unquote_splicing(req_params), optional) do
-        :ok -> :ok
-        {:ok, result} -> result
-        {:error, reason} when is_binary(reason) -> raise Error, message: reason
-        {:error, reason} -> raise Error, message: inspect(reason)
+    if in_opt_spec == [] do
+      # operations without optional arguments
+      def unquote(bang_func_name)(unquote_splicing(req_params)) do
+        case __MODULE__.unquote(func_name)(unquote_splicing(req_params)) do
+          :ok -> :ok
+          {:ok, result} -> result
+          {:error, reason} when is_binary(reason) -> raise Error, message: reason
+          {:error, reason} -> raise Error, message: inspect(reason)
+        end
+      end
+    else
+      # operations with optional arguments
+      def unquote(bang_func_name)(unquote_splicing(req_params), optional \\ []) do
+        case __MODULE__.unquote(func_name)(unquote_splicing(req_params), optional) do
+          :ok -> :ok
+          {:ok, result} -> result
+          {:error, reason} when is_binary(reason) -> raise Error, message: reason
+          {:error, reason} -> raise Error, message: inspect(reason)
+        end
       end
     end
   end)

--- a/lib/vix/vips/operation_helper.ex
+++ b/lib/vix/vips/operation_helper.ex
@@ -78,7 +78,7 @@ defmodule Vix.Vips.OperationHelper do
         {:ok, term}
 
       {required, optional} ->
-        {:ok, List.to_tuple(required ++ [optional])}
+        {:ok, List.to_tuple(required ++ [Map.new(optional)])}
     end
   end
 
@@ -171,7 +171,9 @@ defmodule Vix.Vips.OperationHelper do
         optional_out = optional_args_typespec(optional)
 
         quote do
-          {:ok, {unquote_splicing(required_args_typespec(pspec_list)), unquote(optional_out)}}
+          {:ok,
+           {unquote_splicing(required_args_typespec(pspec_list)),
+            %{unquote_splicing(optional_out)}}}
           | {:error, term()}
         end
     end
@@ -193,7 +195,8 @@ defmodule Vix.Vips.OperationHelper do
         optional_out = optional_args_typespec(optional)
 
         quote do
-          {unquote_splicing(required_args_typespec(pspec_list)), unquote(optional_out)}
+          {unquote_splicing(required_args_typespec(pspec_list)),
+           %{unquote_splicing(optional_out)}}
           | no_return()
         end
     end
@@ -348,11 +351,12 @@ defmodule Vix.Vips.OperationHelper do
 
     """
     ## Returns
-    Ordered values in the returned tuple
+    Operation returns a tuple
+
     #{required_out_values}
 
-    ## Additional
-    Last value of the the output tuple is a keyword list of additional optional output values
+    Last value of the tuple is a map of additional output values as key-value pair.
+
     #{optional_out_values}
     """
   end

--- a/test/vix/vips/operation_test.exs
+++ b/test/vix/vips/operation_test.exs
@@ -67,7 +67,7 @@ defmodule Vix.Vips.OperationTest do
 
   test "required output order", %{dir: _dir} do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
-    assert Operation.find_trim(im) == {:ok, {41, 44, 45, 45, %{}}}
+    assert Operation.find_trim(im) == {:ok, {41, 44, 45, 45}}
   end
 
   test "when unsupported argument is passed", %{dir: _dir} do

--- a/test/vix/vips/operation_test.exs
+++ b/test/vix/vips/operation_test.exs
@@ -61,13 +61,13 @@ defmodule Vix.Vips.OperationTest do
   test "additional return values", %{dir: _dir} do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
 
-    assert {:ok, {0.0, [x: _, y: _, "out-array": [0.0], "x-array": [_ | _], "y-array": [_ | _]]}} =
+    assert {:ok, {0.0, %{x: _, y: _, "out-array": [0.0], "x-array": [_ | _], "y-array": [_ | _]}}} =
              Operation.min(im)
   end
 
   test "required output order", %{dir: _dir} do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
-    assert Operation.find_trim(im) == {:ok, {41, 44, 45, 45, []}}
+    assert Operation.find_trim(im) == {:ok, {41, 44, 45, 45, %{}}}
   end
 
   test "when unsupported argument is passed", %{dir: _dir} do


### PR DESCRIPTION
- Change type of additional output values to map from keyword list
- Skip empty optional argument from function definition when the operation does not have any

Hi @kipcole9! I am making few breaking changes, if possible can you check if this breaks `Image`? 
Btw, I also made few other changes in the master - https://github.com/akash-akya/vix/pull/103. Notably, added limited math operators similar to Image :)