### PR TITLE
Make sure :ssl is available

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -95,7 +95,7 @@ defmodule Vix.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :public_key]
+      extra_applications: [:logger, :public_key, :ssl]
     ]
   end
 


### PR DESCRIPTION
Trying to run an app on Elixir v1.15.0-rc.0 and OTP 26 that depends on `image` I got the following error downloading https://github.com/akash-akya/sharp-libvips/releases/download/v8.14.2-rc2/libvips-8.14.2-darwin-arm64v8.tar.gz

```
{:error,
 {:failed_connect,
  [
    {:to_address, {~c"github.com", 443}},
    {:inet, [:inet],
     {:eoptions,
      {:undef,
       [
         {:ssl, :connect,
         ...
```

I got it working by making sure `:ssl` is included.