### PR TITLE
Vix.LibvipsPrecompiled: system_architecture -> current

### DIFF
--- a/build_scripts/precompiler.exs
+++ b/build_scripts/precompiler.exs
@@ -166,11 +166,11 @@ defmodule Vix.LibvipsPrecompiled do
             if String.match?(Enum.at(current, 2), ~r/^darwin.*/) do
               {:ok, {Enum.at(current, 0), Enum.at(current, 1), "darwin"}}
             else
-              {:ok, List.to_tuple(system_architecture)}
+              {:ok, List.to_tuple(current)}
             end
 
           _ ->
-            {:ok, List.to_tuple(system_architecture)}
+            {:ok, List.to_tuple(current)}
         end
 
       _ ->


### PR DESCRIPTION
I was updating vix on my FreeBSD machine and started debugging why it wasn't building (didn't notice the switch to precompiled libs unless otherwise specified) and while trying to get a valid triple generated for FreeBSD I noticed that this fallback code was incorrect as it was passing the `system_architecture` String through instead of the `current` List.

No other notes, the **VIX_COMPILATION_MODE=PLATFORM_PROVIDED_LIBVIPS** env works fine.