### PR TITLE
Allow returning the mutated image from mutate callback

### DIFF
--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -66,6 +66,6 @@ defmodule Vix.Vips.MutableImageTest do
   test "that returning the mutated image is an acceptable callback return" do
     {:ok, i} = Vix.Vips.Image.new_from_file(img_path("puppies.jpg"))
 
-    assert {:ok, _} = Vix.Vips.Image.mutate(i, &(&1))
+    assert {:ok, _} = Vix.Vips.Image.mutate(i, & &1)
   end
 end

--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -62,4 +62,10 @@ defmodule Vix.Vips.MutableImageTest do
     assert {:ok, {_, false}} =
              Vix.Vips.Image.mutate(i, fn m -> Vix.Vips.MutableImage.has_alpha?(m) end)
   end
+
+  test "that returning the mutated image is an acceptable callback return" do
+    {:ok, i} = Vix.Vips.Image.new_from_file(img_path("puppies.jpg"))
+
+    assert {:ok, _} = Vix.Vips.Image.mutate(i, &(&1))
+  end
 end


### PR DESCRIPTION
* Clarify the acceptable returns from the callback of `Vix.Vips.Image.mutate/2`
* Add retuning the mutated image itself, without decoration, as an acceptable return type. The is helpful with the mutation callback is a pipeline of `!` functions.
