### PR TITLE
Add write_area_to_binary and get_pixel

### DIFF
--- a/c_src/vips_image.h
+++ b/c_src/vips_image.h
@@ -58,4 +58,7 @@ ERL_NIF_TERM nif_image_new_from_binary(ErlNifEnv *env, int argc,
 
 ERL_NIF_TERM nif_image_write_to_binary(ErlNifEnv *env, int argc,
                                        const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM nif_image_write_area_to_binary(ErlNifEnv *env, int argc,
+                                            const ERL_NIF_TERM argv[]);
 #endif

--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -88,6 +88,8 @@ static ErlNifFunc nif_funcs[] = {
      ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"nif_image_write_to_binary", 1, nif_image_write_to_binary,
      ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"nif_image_write_area_to_binary", 2, nif_image_write_area_to_binary,
+     ERL_NIF_DIRTY_JOB_CPU_BOUND},
 
     /* VipsImage UNSAFE */
     {"nif_image_update_metadata", 3, nif_image_update_metadata, 0},

--- a/lib/vix/nif.ex
+++ b/lib/vix/nif.ex
@@ -71,6 +71,9 @@ defmodule Vix.Nif do
   def nif_image_write_to_binary(_vips_image),
     do: :erlang.nif_error(:nif_library_not_loaded)
 
+  def nif_image_write_area_to_binary(_vips_image, _params_list),
+    do: :erlang.nif_error(:nif_library_not_loaded)
+
   # VipsImage *UNSAFE*
   def nif_image_update_metadata(_vips_image, _name, _value),
     do: :erlang.nif_error(:nif_library_not_loaded)

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -1,8 +1,4 @@
 defmodule Vix.Vips.Image do
-  defstruct [:ref]
-
-  alias __MODULE__
-
   @moduledoc """
   Functions for reading and writing images as well as
   accessing and updating image metadata.
@@ -99,6 +95,9 @@ defmodule Vix.Vips.Image do
       %Vix.Vips.Image{ref: #Reference<0.2448791511.2685009949.153742>}
   """
 
+  defstruct [:ref]
+
+  alias __MODULE__
   alias Vix.Nif
   alias Vix.Type
   alias Vix.Vips.MutableImage
@@ -152,7 +151,7 @@ defmodule Vix.Vips.Image do
 
   # Extract band when the band number is positive or zero
   def fetch(image, band) when is_integer(band) and band >= 0 do
-    case Vix.Vips.Operation.extract_band(image, band) do
+    case Operation.extract_band(image, band) do
       {:ok, band} -> {:ok, band}
       {:error, _reason} -> raise ArgumentError, "Invalid band requested. Found #{inspect(band)}"
     end
@@ -179,9 +178,13 @@ defmodule Vix.Vips.Image do
     with {:ok, args} <- normalize_access_args(args),
          {:ok, left, width} <- validate_dimension(args[:width], width(image)),
          {:ok, top, height} <- validate_dimension(args[:height], height(image)),
-         {:ok, first_band, bands} <- validate_dimension(args[:band], bands(image)),
-         {:ok, area} <- extract_area(image, left, top, width, height) do
-      extract_band(area, first_band, n: bands)
+         {:ok, first_band, bands} <- validate_dimension(args[:band], bands(image)) do
+      extracted_image =
+        image
+        |> extract_area!(left, top, width, height)
+        |> extract_band!(first_band, n: bands)
+
+      {:ok, extracted_image}
     else
       {:error, _} ->
         raise ArgumentError, "Argument must be list of integers or ranges or keyword list"
@@ -190,19 +193,19 @@ defmodule Vix.Vips.Image do
 
   @impl Access
   def get_and_update(_image, _key, _fun) do
-    raise "get_and_update/3 for Vix.Vips.Image is not supported."
+    raise ArgumentError, "get_and_update/3 for Vix.Vips.Image is not supported."
   end
 
   @impl Access
   def pop(_image, _band, _default \\ nil) do
-    raise "pop/3 for Vix.Vips.Image is not supported."
+    raise ArgumentError, "pop/3 for Vix.Vips.Image is not supported."
   end
 
   # Extract a range of bands
   defp fetch_range(image, %Range{first: first, last: last}) when first >= 0 and last >= first do
-    case Vix.Vips.Operation.extract_band(image, first, n: last - first + 1) do
+    case Operation.extract_band(image, first, n: last - first + 1) do
       {:ok, band} -> {:ok, band}
-      {:error, _reason} -> raise "Invalid band range #{inspect(first..last)}"
+      {:error, _reason} -> raise Error, "Invalid band range #{inspect(first..last)}"
     end
   end
 
@@ -281,17 +284,25 @@ defmodule Vix.Vips.Image do
     Map.get(range, :step) == 1 || !Map.has_key?(range, :step)
   end
 
-  defp extract_area(image, left, top, width, height) do
+  @spec extract_area!(
+          Image.t(),
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer
+        ) :: Image.t() | no_return
+  defp extract_area!(image, left, top, width, height) do
     case Operation.extract_area(image, left, top, width, height) do
-      {:ok, image} -> {:ok, image}
-      _other -> raise "Requested area could not be extracted"
+      {:ok, image} -> image
+      {:error, _} = _error -> raise Error, "Requested area could not be extracted"
     end
   end
 
-  defp extract_band(area, first_band, options) do
+  @spec extract_band!(Image.t(), non_neg_integer, keyword) :: Image.t() | no_return
+  defp extract_band!(area, first_band, options) do
     case Operation.extract_band(area, first_band, options) do
-      {:ok, image} -> {:ok, image}
-      _other -> raise "Requested band(s) could not be extracted"
+      {:ok, image} -> image
+      {:error, _} = _error -> raise Error, "Requested band(s) could not be extracted"
     end
   end
 
@@ -380,7 +391,7 @@ defmodule Vix.Vips.Image do
   @spec new_from_buffer(binary(), keyword()) :: {:ok, t()} | {:error, term()}
   def new_from_buffer(bin, opts \\ []) do
     with {:ok, loader} <- Vix.Vips.Foreign.find_load_buffer(bin),
-         {:ok, {ref, _optional}} <- Vix.Vips.Operation.Helper.operation_call(loader, [bin], opts) do
+         {:ok, {ref, _optional}} <- Operation.Helper.operation_call(loader, [bin], opts) do
       {:ok, wrap_type(ref)}
     end
   end

--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -199,21 +199,21 @@ defmodule Vix.Vips.Image do
   end
 
   # Extract a range of bands
-  def fetch_range(image, %Range{first: first, last: last}) when first >= 0 and last >= first do
+  defp fetch_range(image, %Range{first: first, last: last}) when first >= 0 and last >= first do
     case Vix.Vips.Operation.extract_band(image, first, n: last - first + 1) do
       {:ok, band} -> {:ok, band}
       {:error, _reason} -> raise "Invalid band range #{inspect(first..last)}"
     end
   end
 
-  def fetch_range(image, %Range{first: first, last: last}) when first >= 0 and last < 0 do
+  defp fetch_range(image, %Range{first: first, last: last}) when first >= 0 and last < 0 do
     case bands(image) + last do
       last when last >= 0 -> fetch(image, first..last)
       _other -> raise ArgumentError, "Resolved invalid band range #{first..last}}"
     end
   end
 
-  def fetch_range(image, %Range{first: first, last: last}) when last < 0 and first < last do
+  defp fetch_range(image, %Range{first: first, last: last}) when last < 0 and first < last do
     bands = bands(image)
     last = bands + last
 
@@ -224,7 +224,7 @@ defmodule Vix.Vips.Image do
     end
   end
 
-  def fetch_range(_image, %Range{} = range) do
+  defp fetch_range(_image, %Range{} = range) do
     raise ArgumentError, "Invalid range #{inspect(range)}"
   end
 
@@ -438,9 +438,6 @@ defmodule Vix.Vips.Image do
   @doc """
   Create a new image from Enumerable.
 
-  > #### Caution {: .warning}
-  > This function is experimental and might cause crashes, use with caution
-
   Returns an image which will lazily pull data from passed
   Enumerable. `enum` should be stream of bytes of an encoded image
   such as JPEG. This functions recognizes the image format and
@@ -511,9 +508,6 @@ defmodule Vix.Vips.Image do
 
   @doc """
   Creates a Stream from Image.
-
-  > #### Caution {: .warning}
-  > This function is experimental and might cause crashes, use with caution
 
   Returns a Stream which will lazily pull data from passed image.
 
@@ -1282,8 +1276,8 @@ defmodule Vix.Vips.Image do
   end
 
   if Kernel.macro_exported?(Logger, :warning, 1) do
-    def log_warn(msg), do: Logger.warning(msg)
+    defp log_warn(msg), do: Logger.warning(msg)
   else
-    def log_warn(msg), do: Logger.warn(msg)
+    defp log_warn(msg), do: Logger.warn(msg)
   end
 end

--- a/test/vix/nif_test.exs
+++ b/test/vix/nif_test.exs
@@ -10,4 +10,14 @@ defmodule Vix.NifTest do
     {:ok, im} = Nif.nif_image_new_from_file(path)
     assert Nif.nif_g_object_type_name(im) == "VipsImage"
   end
+
+  test "nif_image_write_area_to_binary" do
+    path = img_path("puppies.jpg")
+    {:ok, im} = Nif.nif_image_new_from_file(path)
+
+    assert {:ok, {binary, 10 = width, 30 = height, 2 = bands, 0}} =
+             Nif.nif_image_write_area_to_binary(im, [0, 2, 10, 30, 0, 2])
+
+    assert IO.iodata_length(binary) == width * height * bands
+  end
 end

--- a/test/vix/vips/access_test.exs
+++ b/test/vix/vips/access_test.exs
@@ -24,7 +24,7 @@ defmodule Vix.Vips.AccessTest do
   test "Access behaviour for Vix.Vips.Image with invalid range band" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
-    assert_raise RuntimeError, "Invalid band range 1..5", fn ->
+    assert_raise Image.Error, "Invalid band range 1..5", fn ->
       im[1..5]
     end
 

--- a/test/vix/vips/image_test.exs
+++ b/test/vix/vips/image_test.exs
@@ -359,4 +359,27 @@ defmodule Vix.Vips.ImageTest do
     # endianness file written to disk and memory must be same
     assert bin == vbin
   end
+
+  test "get_pixel" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    assert {:ok, [r, g, b]} = Image.get_pixel(im, 10, 10)
+    assert [r, g, b] == [80, 101, 62]
+
+    {:ok, im} = Image.new_from_file(img_path("black.jpg"))
+    assert {:ok, [0]} = Image.get_pixel(im, 10, 10)
+
+    {:ok, im} = Image.new_from_file(img_path("alpha_band.png"))
+    assert {:ok, [r, g, b, a]} = Image.get_pixel(im, 50, 10)
+    assert [r, g, b, a] == [247, 247, 247, 255]
+  end
+
+  test "get_pixel!" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    assert [x, y, z] = Image.get_pixel!(im, 10, 10)
+    assert [x, y, z] == [80, 101, 62]
+
+    assert_raise Image.Error, "Bad extract area. Ensure params are not out of bound", fn ->
+      Image.get_pixel!(im, 10, 1000)
+    end
+  end
 end


### PR DESCRIPTION
Added new generic function `write_area_to_binary` which extracts a region to raw binary in a single NIF call as an optimization. 

`write_to_binary`, `write_to_tensor`, `to_list` and others now use this function so there might be slight performance gain. 

`get_pixel` internally just calls `write_area_to_binary` with width & height 1 and returns a 1D list of band values.

```elixir
# the value will be based on the image band_format and colorspace
{:ok, [r, g, b]} = Image.get_pixel(image, 10, 10)
```

