### PR TITLE
Change image rendering in Livebook

### DIFF
--- a/test/vix/vips/livebook_render_test.exs
+++ b/test/vix/vips/livebook_render_test.exs
@@ -12,14 +12,13 @@ if Code.ensure_loaded?(Kino.Render) do
       assert {:ok, %Image{ref: _ref} = image} = Image.new_from_file(img_path("puppies.jpg"))
 
       assert %{
-               type: :tabs,
-               labels: ["Image", "Attributes"],
+               type: :grid,
+               boxed: false,
+               columns: 1,
+               gap: 8,
                outputs: [
                  %{content: _, mime_type: "image/png", type: :image},
-                 %{
-                   export: true,
-                   type: :js
-                 }
+                 %{export: false, type: :js}
                ]
              } = Kino.Render.to_livebook(image)
     end


### PR DESCRIPTION
@kipcole9 I am thinking of removing the image metadata tabs while rendering the Image in the livebook and show it below the image instead. 

This is for two reasons:
* Tabs does not seem to play nice other components like `grid`
* I often want to have quick glance over these metadata and want to avoid manually switching tabs on re-evaluate

The changes make it look like this, wdyt?

<img width="944" alt="Screenshot 2024-07-27 at 12 25 08 AM" src="https://github.com/user-attachments/assets/753002b3-bd7d-43d2-8be1-67c38e1e912c">
