### PR TITLE
Make new_from_enum and write_to_stream accept keyword opts

### DIFF
--- a/c_src/pipe.c
+++ b/c_src/pipe.c
@@ -385,11 +385,12 @@ static bool cancel_select(ErlNifEnv *env, int *fd) {
 
 static void fd_rt_dtor(ErlNifEnv *env, void *obj) {
   debug("fd_rt_dtor called");
+  int *fd = (int *)obj;
+  close_fd(fd);
 }
 
 static void fd_rt_stop(ErlNifEnv *env, void *obj, int fd, int is_direct_call) {
   debug("fd_rt_stop called %d", fd);
-  close_fd(&fd);
 }
 
 static void fd_rt_down(ErlNifEnv *env, void *obj, ErlNifPid *pid,

--- a/c_src/vips_foreign.c
+++ b/c_src/vips_foreign.c
@@ -135,6 +135,71 @@ exit:
   return ret;
 }
 
+
+ERL_NIF_TERM nif_foreign_find_load_source(ErlNifEnv *env, int argc,
+                                          const ERL_NIF_TERM argv[]) {
+  ASSERT_ARGC(argc, 1);
+
+  ErlNifTime start;
+  ERL_NIF_TERM ret;
+  VipsSource *source;
+  const char *name;
+
+  start = enif_monotonic_time(ERL_NIF_USEC);
+
+  if (!erl_term_to_g_object(env, argv[0], (GObject **)&source)) {
+    ret = make_error(env, "Failed to get VipsSource");
+    goto exit;
+  }
+
+  name = vips_foreign_find_load_source(source);
+
+  if (!name) {
+    error("Failed to find the loader for the source. error: %s", vips_error_buffer());
+    vips_error_clear();
+    ret = make_error(env, "Failed to find loader for the source");
+    goto exit;
+  }
+
+  ret = make_ok(env, make_binary(env, name));
+
+exit:
+  notify_consumed_timeslice(env, start, enif_monotonic_time(ERL_NIF_USEC));
+  return ret;
+}
+
+ERL_NIF_TERM nif_foreign_find_save_target(ErlNifEnv *env, int argc,
+                                          const ERL_NIF_TERM argv[]) {
+  ASSERT_ARGC(argc, 1);
+
+  ErlNifTime start;
+  ERL_NIF_TERM ret;
+  char suffix[VIPS_PATH_MAX];
+  const char *name;
+
+  start = enif_monotonic_time(ERL_NIF_USEC);
+
+  if (!get_binary(env, argv[0], suffix, VIPS_PATH_MAX)) {
+    ret = make_error(env, "Failed to get suffix");
+    goto exit;
+  }
+
+  name = vips_foreign_find_save_target(suffix);
+
+  if (!name) {
+    error("Failed to find saver for the target. error: %s", vips_error_buffer());
+    vips_error_clear();
+    ret = make_error(env, "Failed to find saver for the target");
+    goto exit;
+  }
+
+  ret = make_ok(env, make_binary(env, name));
+
+exit:
+  notify_consumed_timeslice(env, start, enif_monotonic_time(ERL_NIF_USEC));
+  return ret;
+}
+
 ERL_NIF_TERM nif_foreign_get_suffixes(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]) {
   ASSERT_ARGC(argc, 0);

--- a/c_src/vips_foreign.c
+++ b/c_src/vips_foreign.c
@@ -135,7 +135,6 @@ exit:
   return ret;
 }
 
-
 ERL_NIF_TERM nif_foreign_find_load_source(ErlNifEnv *env, int argc,
                                           const ERL_NIF_TERM argv[]) {
   ASSERT_ARGC(argc, 1);
@@ -155,7 +154,8 @@ ERL_NIF_TERM nif_foreign_find_load_source(ErlNifEnv *env, int argc,
   name = vips_foreign_find_load_source(source);
 
   if (!name) {
-    error("Failed to find the loader for the source. error: %s", vips_error_buffer());
+    error("Failed to find the loader for the source. error: %s",
+          vips_error_buffer());
     vips_error_clear();
     ret = make_error(env, "Failed to find loader for the source");
     goto exit;
@@ -187,7 +187,8 @@ ERL_NIF_TERM nif_foreign_find_save_target(ErlNifEnv *env, int argc,
   name = vips_foreign_find_save_target(suffix);
 
   if (!name) {
-    error("Failed to find saver for the target. error: %s", vips_error_buffer());
+    error("Failed to find saver for the target. error: %s",
+          vips_error_buffer());
     vips_error_clear();
     ret = make_error(env, "Failed to find saver for the target");
     goto exit;

--- a/c_src/vips_foreign.h
+++ b/c_src/vips_foreign.h
@@ -15,6 +15,12 @@ ERL_NIF_TERM nif_foreign_find_load(ErlNifEnv *env, int argc,
 ERL_NIF_TERM nif_foreign_find_save(ErlNifEnv *env, int argc,
                                    const ERL_NIF_TERM argv[]);
 
+ERL_NIF_TERM nif_foreign_find_load_source(ErlNifEnv *env, int argc,
+                                   const ERL_NIF_TERM argv[]);
+
+ERL_NIF_TERM nif_foreign_find_save_target(ErlNifEnv *env, int argc,
+                                   const ERL_NIF_TERM argv[]);
+
 ERL_NIF_TERM nif_foreign_get_suffixes(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]);
 

--- a/c_src/vips_foreign.h
+++ b/c_src/vips_foreign.h
@@ -16,10 +16,10 @@ ERL_NIF_TERM nif_foreign_find_save(ErlNifEnv *env, int argc,
                                    const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM nif_foreign_find_load_source(ErlNifEnv *env, int argc,
-                                   const ERL_NIF_TERM argv[]);
+                                          const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM nif_foreign_find_save_target(ErlNifEnv *env, int argc,
-                                   const ERL_NIF_TERM argv[]);
+                                          const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM nif_foreign_get_suffixes(ErlNifEnv *env, int argc,
                                       const ERL_NIF_TERM argv[]);

--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -153,10 +153,11 @@ static ErlNifFunc nif_funcs[] = {
      0},
 
     /* VipsForeign */
-    {"nif_foreign_find_load", 1, nif_foreign_find_load,
-     ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes form the file
+    {"nif_foreign_find_load", 1, nif_foreign_find_load, 0},
     {"nif_foreign_find_save", 1, nif_foreign_find_save, 0},
-    {"nif_foreign_find_load_buffer", 1, nif_foreign_find_load_buffer, 0},
+    {"nif_foreign_find_load_buffer", 1, nif_foreign_find_load_buffer,
+     ERL_NIF_DIRTY_JOB_IO_BOUND},
+    // it might read bytes form the file
     {"nif_foreign_find_save_buffer", 1, nif_foreign_find_save_buffer, 0},
     {"nif_foreign_find_load_source", 1, nif_foreign_find_load_source,
      ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes from source

--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -153,10 +153,12 @@ static ErlNifFunc nif_funcs[] = {
      0},
 
     /* VipsForeign */
-    {"nif_foreign_find_load", 1, nif_foreign_find_load, 0},
+    {"nif_foreign_find_load", 1, nif_foreign_find_load, ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes form the file
     {"nif_foreign_find_save", 1, nif_foreign_find_save, 0},
     {"nif_foreign_find_load_buffer", 1, nif_foreign_find_load_buffer, 0},
     {"nif_foreign_find_save_buffer", 1, nif_foreign_find_save_buffer, 0},
+    {"nif_foreign_find_load_source", 1, nif_foreign_find_load_source, ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes from source
+    {"nif_foreign_find_save_target", 1, nif_foreign_find_save_target, 0},
     {"nif_foreign_get_suffixes", 0, nif_foreign_get_suffixes, 0},
     {"nif_foreign_get_loader_suffixes", 0, nif_foreign_get_loader_suffixes, 0},
 

--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -153,11 +153,13 @@ static ErlNifFunc nif_funcs[] = {
      0},
 
     /* VipsForeign */
-    {"nif_foreign_find_load", 1, nif_foreign_find_load, ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes form the file
+    {"nif_foreign_find_load", 1, nif_foreign_find_load,
+     ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes form the file
     {"nif_foreign_find_save", 1, nif_foreign_find_save, 0},
     {"nif_foreign_find_load_buffer", 1, nif_foreign_find_load_buffer, 0},
     {"nif_foreign_find_save_buffer", 1, nif_foreign_find_save_buffer, 0},
-    {"nif_foreign_find_load_source", 1, nif_foreign_find_load_source, ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes from source
+    {"nif_foreign_find_load_source", 1, nif_foreign_find_load_source,
+     ERL_NIF_DIRTY_JOB_IO_BOUND}, // it might read bytes from source
     {"nif_foreign_find_save_target", 1, nif_foreign_find_save_target, 0},
     {"nif_foreign_get_suffixes", 0, nif_foreign_get_suffixes, 0},
     {"nif_foreign_get_loader_suffixes", 0, nif_foreign_get_loader_suffixes, 0},

--- a/lib/vix/nif.ex
+++ b/lib/vix/nif.ex
@@ -186,6 +186,12 @@ defmodule Vix.Nif do
   def nif_foreign_find_save(_filename),
     do: :erlang.nif_error(:nif_library_not_loaded)
 
+  def nif_foreign_find_load_source(_source),
+    do: :erlang.nif_error(:nif_library_not_loaded)
+
+  def nif_foreign_find_save_target(_suffix),
+    do: :erlang.nif_error(:nif_library_not_loaded)
+
   def nif_foreign_get_suffixes,
     do: :erlang.nif_error(:nif_library_not_loaded)
 

--- a/lib/vix/target_pipe.ex
+++ b/lib/vix/target_pipe.ex
@@ -7,17 +7,20 @@ defmodule Vix.TargetPipe do
 
   @moduledoc false
 
+  @type t() :: struct
+
   defstruct [:fd, :pending, :task_result, :task_pid]
 
   defmodule Pending do
     @moduledoc false
-    defstruct size: nil, client_pid: nil
+    defstruct size: nil, client_pid: nil, opts: []
   end
 
   @default_buffer_size 65_535
 
-  def new(vips_image, suffix) do
-    GenServer.start_link(__MODULE__, %{image: vips_image, suffix: suffix})
+  @spec new(Vix.Vips.Image.t(), String.t(), keyword) :: GenServer.on_start()
+  def new(image, suffix, opts) do
+    GenServer.start_link(__MODULE__, %{image: image, suffix: suffix, opts: opts})
   end
 
   def read(process, max_size \\ @default_buffer_size)
@@ -31,15 +34,15 @@ defmodule Vix.TargetPipe do
 
   # Server
 
-  def init(%{image: image, suffix: suffix}) do
+  def init(%{image: image, suffix: suffix, opts: opts}) do
     Process.flag(:trap_exit, true)
-    {:ok, nil, {:continue, %{image: image, suffix: suffix}}}
+    {:ok, nil, {:continue, %{image: image, suffix: suffix, opts: opts}}}
   end
 
-  def handle_continue(%{image: image, suffix: suffix}, _) do
+  def handle_continue(%{image: image, suffix: suffix, opts: opts}, _) do
     case Nif.nif_target_new() do
       {:ok, {fd, target}} ->
-        pid = start_task(image, target, suffix)
+        pid = start_task(image, %Vix.Vips.Target{ref: target}, suffix, opts)
         {:noreply, %TargetPipe{fd: fd, task_pid: pid, pending: %Pending{}}}
 
       {:error, reason} ->
@@ -98,9 +101,21 @@ defmodule Vix.TargetPipe do
     {:noreply, state}
   end
 
-  defp start_task(image, target, suffix) do
+  @spec start_task(Vix.Vips.Image.t(), Vix.Vips.Target.t(), String.t(), keyword) :: pid
+  defp start_task(%Vix.Vips.Image{} = image, target, suffix, []) do
     spawn_link(fn ->
-      result = Nif.nif_image_to_target(image, target, suffix)
+      result = Nif.nif_image_to_target(image.ref, target.ref, suffix)
+      Process.exit(self(), result)
+    end)
+  end
+
+  defp start_task(image, target, suffix, opts) do
+    spawn_link(fn ->
+      result =
+        with {:ok, saver} <- Vix.Vips.Foreign.find_save_target(suffix) do
+          Vix.Vips.Operation.Helper.operation_call(saver, [image, target], opts)
+        end
+
       Process.exit(self(), result)
     end)
   end

--- a/lib/vix/vips/foreign.ex
+++ b/lib/vix/vips/foreign.ex
@@ -1,21 +1,44 @@
 defmodule Vix.Vips.Foreign do
-  alias Vix.Nif
   @moduledoc false
 
+  alias Vix.Nif
+
+  @type operation_name :: String.t()
+
+  @spec find_load_buffer(binary) :: {:ok, operation_name} | {:error, String.t()}
   def find_load_buffer(bin) do
     Nif.nif_foreign_find_load_buffer(bin)
   end
 
+  @spec find_save_buffer(String.t()) :: {:ok, operation_name} | {:error, String.t()}
   def find_save_buffer(suffix) do
     Nif.nif_foreign_find_save_buffer(suffix)
   end
 
+  @doc """
+  Returns Vips operation name which can load the passed file
+  """
+  @spec find_load(String.t()) :: {:ok, operation_name} | {:error, String.t()}
   def find_load(filename) do
     Nif.nif_foreign_find_load(filename)
   end
 
+  @doc """
+  Returns Vips operation name which can save an image to passed format
+  """
+  @spec find_save(String.t()) :: {:ok, operation_name} | {:error, String.t()}
   def find_save(filename) do
     Nif.nif_foreign_find_save(filename)
+  end
+
+  @spec find_load_source(Vix.Vips.Source.t()) :: {:ok, operation_name} | {:error, String.t()}
+  def find_load_source(source) do
+    Nif.nif_foreign_find_load_source(source)
+  end
+
+  @spec find_save_target(String.t()) :: {:ok, operation_name} | {:error, String.t()}
+  def find_save_target(suffix) do
+    Nif.nif_foreign_find_save_target(suffix)
   end
 
   def get_suffixes do

--- a/lib/vix/vips/foreign.ex
+++ b/lib/vix/vips/foreign.ex
@@ -32,8 +32,8 @@ defmodule Vix.Vips.Foreign do
   end
 
   @spec find_load_source(Vix.Vips.Source.t()) :: {:ok, operation_name} | {:error, String.t()}
-  def find_load_source(source) do
-    Nif.nif_foreign_find_load_source(source)
+  def find_load_source(%Vix.Vips.Source{ref: vips_source}) do
+    Nif.nif_foreign_find_load_source(vips_source)
   end
 
   @spec find_save_target(String.t()) :: {:ok, operation_name} | {:error, String.t()}

--- a/lib/vix/vips/source.ex
+++ b/lib/vix/vips/source.ex
@@ -2,9 +2,13 @@ defmodule Vix.Vips.Source do
   @moduledoc false
 
   alias Vix.Type
+  alias __MODULE__
 
   @behaviour Type
-  @opaque t() :: reference()
+
+  @type t() :: %Source{ref: reference}
+
+  defstruct [:ref]
 
   @impl Type
   def typespec do
@@ -17,8 +21,16 @@ defmodule Vix.Vips.Source do
   def default(nil), do: :unsupported
 
   @impl Type
-  def to_nif_term(_value, _data), do: raise("VipsSource is not implemented yet")
+  def to_nif_term(source, _data) do
+    case source do
+      %Source{ref: ref} ->
+        ref
+
+      value ->
+        raise ArgumentError, message: "expected Vix.Vips.Source given: #{inspect(value)}"
+    end
+  end
 
   @impl Type
-  def to_erl_term(_value), do: raise("VipsSource is not implemented yet")
+  def to_erl_term(ref), do: %Source{ref: ref}
 end

--- a/lib/vix/vips/target.ex
+++ b/lib/vix/vips/target.ex
@@ -2,9 +2,13 @@ defmodule Vix.Vips.Target do
   @moduledoc false
 
   alias Vix.Type
+  alias __MODULE__
 
   @behaviour Type
-  @opaque t() :: reference()
+
+  @type t() :: %Target{ref: reference()}
+
+  defstruct [:ref]
 
   @impl Type
   def typespec do
@@ -17,8 +21,16 @@ defmodule Vix.Vips.Target do
   def default(nil), do: :unsupported
 
   @impl Type
-  def to_nif_term(_value, _data), do: raise("VipsTarget is not implemented yet")
+  def to_nif_term(target, _data) do
+    case target do
+      %Target{ref: ref} ->
+        ref
+
+      value ->
+        raise ArgumentError, message: "expected Vix.Vips.Source given: #{inspect(value)}"
+    end
+  end
 
   @impl Type
-  def to_erl_term(_value), do: raise("VipsTarget is not implemented yet")
+  def to_erl_term(ref), do: %Target{ref: ref}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -131,7 +131,7 @@ defmodule Vix.MixProject do
         {:dialyxir, "~> 1.4", only: [:dev], runtime: false},
         {:ex_doc, ">= 0.0.0", only: :dev},
         {:excoveralls, "~> 0.15", only: :test},
-        {:temp, "~> 0.4", only: :test, runtime: false}
+        {:briefly, "~> 0.5.0", only: :test}
       ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "briefly": {:hex, :briefly, "0.5.1", "ee10d48da7f79ed2aebdc3e536d5f9a0c3e36ff76c0ad0d4254653a152b13a8a", [:mix], [], "hexpm", "bd684aa92ad8b7b4e0d92c31200993c4bc1469fc68cd6d5f15144041bd15cb57"},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "castore": {:hex, :castore, "1.0.10", "43bbeeac820f16c89f79721af1b3e092399b3a1ecc8df1a472738fd853574911", [:mix], [], "hexpm", "1b0b7ea14d889d9ea21202c43a4fa015eb913021cb535e8ed91946f4b77a8848"},
   "cc_precompiler": {:hex, :cc_precompiler, "0.1.10", "47c9c08d8869cf09b41da36538f62bc1abd3e19e41701c2cea2675b53c704258", [:mix], [{:elixir_make, "~> 0.7", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "f6e046254e53cd6b41c6bacd70ae728011aa82b2742a80d6e2214855c6e06b22"},
@@ -18,5 +19,4 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "table": {:hex, :table, "0.1.2", "87ad1125f5b70c5dea0307aa633194083eb5182ec537efc94e96af08937e14a8", [:mix], [], "hexpm", "7e99bc7efef806315c7e65640724bf165c3061cdc5d854060f74468367065029"},
-  "temp": {:hex, :temp, "0.4.9", "eb6355bfa7925a568b3d9eb3bb57e89aa6d2b78bfe8dfb6b698e090631b7f41f", [:mix], [], "hexpm", "bc8bf7b27d9105bef933ef4bf4ba37ac6b899dbeba329deaa88c60b62d6b4b6d"},
 }

--- a/test/vix/foreign_test.exs
+++ b/test/vix/foreign_test.exs
@@ -20,4 +20,18 @@ defmodule Vix.Vips.ForeignTest do
   test "find_save" do
     assert {:ok, "VipsForeignSaveJpegFile"} = Foreign.find_save("puppies.jpg")
   end
+
+  test "find_load_source" do
+    bin = File.read!(img_path("puppies.jpg"))
+
+    assert {pipe, source} = Vix.SourcePipe.new()
+    assert :ok = Vix.SourcePipe.write(pipe, bin)
+    assert :ok = Vix.SourcePipe.stop(pipe)
+
+    assert {:ok, "VipsForeignLoadJpegSource"} = Foreign.find_load_source(source)
+  end
+
+  test "find_save_target" do
+    assert {:ok, "VipsForeignSaveJpegTarget"} = Foreign.find_save_target(".jpg")
+  end
 end

--- a/test/vix/vips/operation/helper_test.exs
+++ b/test/vix/vips/operation/helper_test.exs
@@ -6,13 +6,7 @@ defmodule Vix.Vips.Operation.HelperTest do
 
   import Vix.Support.Images
 
-  setup do
-    Temp.track!()
-    dir = Temp.mkdir!()
-    {:ok, %{dir: dir}}
-  end
-
-  test "operation_call", %{dir: dir} do
+  test "operation_call" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
     assert {:ok, out} =
@@ -22,7 +16,7 @@ defmodule Vix.Vips.Operation.HelperTest do
                extend: :VIPS_EXTEND_COPY
              )
 
-    out_path = Temp.path!(suffix: ".jpg", basedir: dir)
+    out_path = Briefly.create!(extname: ".jpg")
     :ok = Image.write_to_file(out, out_path)
 
     assert_files_equal(img_path("gravity_puppies.jpg"), out_path)

--- a/test/vix/vips/operation_test.exs
+++ b/test/vix/vips/operation_test.exs
@@ -6,33 +6,27 @@ defmodule Vix.Vips.OperationTest do
 
   import Vix.Support.Images
 
-  setup do
-    Temp.track!()
-    dir = Temp.mkdir!()
-    {:ok, %{dir: dir}}
-  end
-
-  test "invert", %{dir: dir} do
+  test "invert" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert {:ok, out} = Operation.invert(im)
 
-    out_path = Temp.path!(suffix: ".jpg", basedir: dir)
+    out_path = Briefly.create!(extname: ".jpg")
     :ok = Image.write_to_file(out, out_path)
 
     assert_files_equal(img_path("invert_puppies.jpg"), out_path)
   end
 
-  test "affine", %{dir: dir} do
+  test "affine" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     assert {:ok, out} = Operation.affine(im, [1, 0, 0, 0.5])
 
-    out_path = Temp.path!(suffix: ".jpg", basedir: dir)
+    out_path = Briefly.create!(extname: ".jpg")
     :ok = Image.write_to_file(out, out_path)
 
     assert_files_equal(img_path("affine_puppies.jpg"), out_path)
   end
 
-  test "gravity", %{dir: dir} do
+  test "gravity" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
 
     assert {:ok, out} =
@@ -40,25 +34,25 @@ defmodule Vix.Vips.OperationTest do
                extend: :VIPS_EXTEND_COPY
              )
 
-    out_path = Temp.path!(suffix: ".jpg", basedir: dir)
+    out_path = Briefly.create!(extname: ".jpg")
     :ok = Image.write_to_file(out, out_path)
 
     assert_files_equal(img_path("gravity_puppies.jpg"), out_path)
   end
 
-  test "conv with simple edge detection kernel", %{dir: dir} do
+  test "conv with simple edge detection kernel" do
     {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
     {:ok, mask} = Image.new_matrix_from_array(3, 3, [[-1, -1, -1], [-1, 8, -1], [-1, -1, -1]])
 
     assert {:ok, out} = Operation.conv(im, mask, precision: :VIPS_PRECISION_FLOAT)
 
-    out_path = Temp.path!(suffix: ".jpg", basedir: dir)
+    out_path = Briefly.create!(extname: ".jpg")
     :ok = Image.write_to_file(out, out_path)
 
     assert_files_equal(img_path("conv_puppies.jpg"), out_path)
   end
 
-  test "additional return values", %{dir: _dir} do
+  test "additional return values" do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
 
     assert {:ok, {min, %{x: _, y: _, "out-array": [min], "x-array": [_ | _], "y-array": [_ | _]}}} =
@@ -67,17 +61,17 @@ defmodule Vix.Vips.OperationTest do
     assert min in [-0.0, +0.0]
   end
 
-  test "required output order", %{dir: _dir} do
+  test "required output order" do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
     assert Operation.find_trim(im) == {:ok, {41, 44, 45, 45}}
   end
 
-  test "when unsupported argument is passed", %{dir: _dir} do
+  test "when unsupported argument is passed" do
     buf = File.read!(img_path("alpha_band.png"))
     assert {:ok, {%Image{}, _}} = Operation.pngload_buffer(buf, foo: "bar")
   end
 
-  test "operation error", %{dir: _dir} do
+  test "operation error" do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
 
     assert Operation.affine(im, [1, 1, 1, 1]) ==
@@ -85,17 +79,17 @@ defmodule Vix.Vips.OperationTest do
               "operation build: vips__transform_calc_inverse: singular or near-singular matrix"}
   end
 
-  test "image type mismatch error", %{dir: _dir} do
+  test "image type mismatch error" do
     assert_raise ArgumentError, "expected Vix.Vips.Image. given: :invalid", fn ->
       Operation.invert(:invalid)
     end
   end
 
-  test "enum parameter", %{dir: dir} do
+  test "enum parameter" do
     {:ok, im} = Image.new_from_file(img_path("black_on_white.jpg"))
     {:ok, out} = Operation.flip(im, :VIPS_DIRECTION_HORIZONTAL)
 
-    out_path = Temp.path!(suffix: ".jpg", basedir: dir)
+    out_path = Briefly.create!(extname: ".jpg")
     :ok = Image.write_to_file(out, out_path)
 
     assert_files_equal(img_path("black_on_white_hflip.jpg"), out_path)


### PR DESCRIPTION
* correct dirty IO schedulers
* switch from temp to briefly for generating temp paths in tests
* fix a race-condition in pipe close