### PR TITLE
Ensure Janitor is always autoloaded

### DIFF
--- a/lib/vix/nif.ex
+++ b/lib/vix/nif.ex
@@ -6,6 +6,12 @@ defmodule Vix.Nif do
     @moduledoc false
     use GenServer
 
+    # Because Vix needs to run NIFs at compile-time and the `@on_load`
+    # callback uses the Janitor, let's ensure the Janitor is explicitly
+    # loaded after compilation, otherwise the Janitor may not be found
+    # from within the `@on_load` callback.
+    @compile {:autoload, true}
+
     # Singleton process to safely cleanup native resources
     alias __MODULE__
 


### PR DESCRIPTION
We are exploring lazily loading modules in Elixir to improve compilation times and there was a regression in Vix. This changes ensures forward compatibility without changing the behaviour for previous versions.