### PR TITLE
Fix BEAM segfault on unknown operation names

### DIFF
--- a/c_src/vips_operation.c
+++ b/c_src/vips_operation.c
@@ -229,6 +229,10 @@ ERL_NIF_TERM nif_vips_operation_call(ErlNifEnv *env, int argc,
   }
 
   op = vips_operation_new(op_name);
+  if (!op) {
+    SET_RESULT_FROM_VIPS_ERROR(env, "failed to create operation", res);
+    goto exit;
+  }
 
   res = set_operation_properties(env, op, argv[1]);
   if (!res.is_success)
@@ -284,6 +288,12 @@ ERL_NIF_TERM nif_vips_operation_get_arguments(ErlNifEnv *env, int argc,
   }
 
   op = vips_operation_new(op_name);
+  if (!op) {
+    ERL_NIF_TERM reason = make_binary(env, "failed to create operation");
+    vips_error_clear();
+    result = enif_raise_exception(env, reason);
+    goto exit;
+  }
 
   if (get_vips_operation_args(op, &names, &flags, &n_args) != 0) {
     error("failed to get VipsObject arguments. error: %s", vips_error_buffer());


### PR DESCRIPTION
`nif_vips_operation_call/2` and `nif_vips_operation_get_arguments/1` pass
the result of `vips_operation_new()` to `VIPS_OBJECT()` without checking
for NULL. When libvips doesn't recognize the operation name, it returns
NULL and the subsequent dereference segfaults the entire VM.

## Reproduction


```elixir
iex> :erlang.apply(Vix.Nif, :nif_vips_operation_call, ["bogus", []])
zsh: segmentation fault  iex -S mix

iex> Vix.Nif.nif_vips_operation_get_arguments("bogus")
zsh: segmentation fault  iex -S mix
```

## Fix
Check for NULL after each `vips_operation_new()` call and return a proper
error to Elixir instead of dereferencing. Matches the existing NULL-check
pattern used consistently across the image-construction NIFs
(`nif_image_new_from_file`, `nif_image_new`, etc.).

## After
```elixir
iex> :erlang.apply(Vix.Nif, :nif_vips_operation_call, ["bogus", []])
{:error,
 {"failed to create operation", "VipsOperation: class \"bogus\" not found\n"}}

iex> Vix.Nif.nif_vips_operation_get_arguments("bogus")
** (ErlangError) Erlang error: "failed to create operation"
    (vix 0.38.0) Vix.Nif.nif_vips_operation_get_arguments("bogus")
    iex:1: (file)
```

## Note on `raise_exception` helper
While making fix for `nif_vips_operation_get_arguments`, I ran
into an odd issue: calling the existing `raise_exception()` helper from
`utils.c` segfaults on macOS (Apple Silicon, clang), even though an
equivalent inlined version of the same code works correctly.
Calling it crashes. Inlining the same two operations directly into the
NIF works fine. I haven't isolated the root cause — possibly compiler-
or platform-specific behavior around the helper's return path — so this
PR sidesteps it by inlining instead of touching `utils.c`. Worth a
separate investigation, since other NIFs in the codebase rely on this
helper and could hit the same crash in their error paths (they just
rarely execute those paths).

## Inconsistency?

The two NIFs use different error-reporting styles: `nif_vips_operation_call`
returns `{:error, _}` tuples, while `nif_vips_operation_get_arguments`
raises exceptions. This PR follows the existing convention of each
function rather than unifying them.