### PR TITLE
Close pipe fd when owner process exits

### DIFF
--- a/c_src/pipe.c
+++ b/c_src/pipe.c
@@ -391,6 +391,8 @@ static void fd_rt_dtor(ErlNifEnv *env, void *obj) {
 
 static void fd_rt_stop(ErlNifEnv *env, void *obj, int fd, int is_direct_call) {
   debug("fd_rt_stop called %d", fd);
+  int *fd_r = (int *)obj;
+  close_fd(fd_r);
 }
 
 static void fd_rt_down(ErlNifEnv *env, void *obj, ErlNifPid *pid,

--- a/test/vix/nif_test.exs
+++ b/test/vix/nif_test.exs
@@ -20,4 +20,56 @@ defmodule Vix.NifTest do
 
     assert IO.iodata_length(binary) == width * height * bands
   end
+
+  test "target read fd closes when owner exits" do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, {read_fd, _target}} = Nif.nif_target_new()
+        send(parent, {:target_read_fd, read_fd})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive {:target_read_fd, read_fd}, 1_000
+
+    ref = Process.monitor(owner)
+    send(owner, :stop)
+
+    assert_receive {:DOWN, ^ref, :process, ^owner, :normal}
+    assert {:error, "Bad file descriptor"} = Nif.nif_read(read_fd, 1)
+  end
+
+  test "target read fd closes when owner exits after waiting for input" do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, {read_fd, _target}} = Nif.nif_target_new()
+        send(parent, {:target_read_fd, read_fd})
+
+        receive do
+          :select ->
+            send(parent, {:select_result, Nif.nif_read(read_fd, 1)})
+        end
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive {:target_read_fd, read_fd}, 1_000
+
+    send(owner, :select)
+    assert_receive {:select_result, {:error, :eagain}}, 1_000
+
+    ref = Process.monitor(owner)
+    send(owner, :stop)
+
+    assert_receive {:DOWN, ^ref, :process, ^owner, :normal}
+    assert {:error, "Bad file descriptor"} = Nif.nif_read(read_fd, 1)
+  end
 end


### PR DESCRIPTION
I encountered this issue while playing around with Vix streams: When halting a stream early, it seems like the target pipe `fd` can stay open until resource gc/cleanup.

I've added a regression test, asserting `"Bad file descriptor"` instead of `:eagain` after the owner process exits. The fix makes `fd_rt_stop` call `close_fd` on the NIF resource `fd`. I noticed there was an earlier commit 422fcfe8 aiming to fix a race condition, where `close_fd` was moved out of `fd_rt_stop`. Could that have been because the `close_fd` in `fd_rt_stop` was passed the call-by-value `fd`?

Note that I'm not a C/NIF expert, so I hope I haven't missed some lifecycle nuances here.