### PR TITLE
Fix NIF registration: nif_vips_tracked_get_mem_highwater bound to wrong function

### DIFF
--- a/c_src/vix.c
+++ b/c_src/vix.c
@@ -133,7 +133,7 @@ static ErlNifFunc nif_funcs[] = {
     {"nif_vips_cache_get_max_mem", 0, nif_vips_cache_get_max_mem, 0},
     {"nif_vips_leak_set", 1, nif_vips_leak_set, 0},
     {"nif_vips_tracked_get_mem", 0, nif_vips_tracked_get_mem, 0},
-    {"nif_vips_tracked_get_mem_highwater", 0, nif_vips_tracked_get_mem, 0},
+    {"nif_vips_tracked_get_mem_highwater", 0, nif_vips_tracked_get_mem_highwater, 0},
     {"nif_vips_version", 0, nif_vips_version, 0},
     {"nif_vips_shutdown", 0, nif_vips_shutdown, 0},
     {"nif_vips_nickname_find", 1, nif_vips_nickname_find, 0},

--- a/test/vix/vips_test.exs
+++ b/test/vix/vips_test.exs
@@ -20,5 +20,6 @@ defmodule Vix.VipsTest do
 
     usage = Vips.tracked_get_mem_highwater()
     assert is_integer(usage) && usage > 0
+    assert usage >= Vips.tracked_get_mem()
   end
 end


### PR DESCRIPTION
Encountered this while doing some benchmarking.

Fixes `tracked_get_mem_highwater/0` to call the correct NIF function so it returns peak tracked memory instead of current memory, and adds a regression assertion covering the expected highwater behavior.

Fixes #213