### PR TITLE
Copy libvips error buffer under lock to avoid torn error messages

### DIFF
--- a/c_src/utils.h
+++ b/c_src/utils.h
@@ -49,13 +49,21 @@ extern guint VIX_LOG_LEVEL;
     error(reason);                                                             \
   } while (0)
 
+/* vips_error_buffer() returns a raw pointer into libvips' shared static error
+ * buffer *after* dropping the global lock, so the strlen/memcpy in
+ * make_binary() races with any other thread appending to or clearing that
+ * buffer. vips_error_buffer_copy() (libvips >= 8.9) g_strdup()s the text and
+ * rewinds the buffer while still holding the lock, which removes the torn read
+ * and also closes the read-then-clear window this macro used to leave open.
+ */
 #define SET_RESULT_FROM_VIPS_ERROR(env, label, res)                            \
   do {                                                                         \
+    char *vix_error_message = vips_error_buffer_copy();                        \
     res.is_success = false;                                                    \
     res.result = enif_make_tuple2(env, make_binary(env, label),                \
-                                  make_binary(env, vips_error_buffer()));      \
-    error("%s: %s", label, vips_error_buffer());                               \
-    vips_error_clear();                                                        \
+                                  make_binary(env, vix_error_message));        \
+    error("%s: %s", label, vix_error_message);                                 \
+    g_free(vix_error_message);                                                 \
   } while (0)
 
 #define SET_VIX_RESULT(res, term)                                              \


### PR DESCRIPTION
@hlindset has been doing some fabulous work on `image` and noticed that error message output isn’t thread safe. 

Since you know already my C-fu is not very good I asked Claude to help craft a PR for Vix. Vix itself can't full resolve the issue, but it's quite a simple PR for Vix and I don't image it will get fixed upstream in libvips.

## Summary

`SET_RESULT_FROM_VIPS_ERROR` reads libvips' shared error buffer through `vips_error_buffer()`, which returns a raw pointer into a process-wide static array *after* releasing libvips' global lock. `make_binary()` then walks that pointer twice — `strlen` then `memcpy` — with no lock held, while other threads are appending to and clearing the same array.

The result is torn error messages. Under concurrency an error binary can come back as a truncated prefix, an embedded `NUL`, and up to ~10 KB of a *different* request's error text — including file paths and any other data libvips echoed into its message. Every `Vix.Vips.Operation.*` call goes through this path.

`libvips` has shipped the appropriate accessor since 8.9.0: `vips_error_buffer_copy()` does the `g_strdup` and the rewind while still holding the lock. The PR removes the race entirely in my testing.

Two further consequences of the same macro:

* It reads the buffer **twice** (once for the tuple, once for the `error(...)` log), so the returned term and the log line can disagree.
* The gap between the read and `vips_error_clear()` lets another thread append a message that is then destroyed unread.

All NIFs that reach this run on dirty schedulers, so N concurrent OS threads is the normal case, and libvips' own pipeline workers append to the same buffer independently.

## Reproducer

The signature of a torn read is an **embedded NUL byte** in the returned binary — a correctly-read C string cannot contain one. Half the tasks use a long path (long error text) and half a short one, to widen the window.

```elixir
dir = Path.join(System.tmp_dir!(), "vix_error_race")
File.rm_rf!(dir)

long_dir = Path.join(dir, String.duplicate("d", 200))
File.mkdir_p!(long_dir)

long = Path.join(long_dir, String.duplicate("L", 200) <> ".jpg")
short = Path.join(dir, "s.jpg")
File.write!(long, <<0x41, 0x42, 0x43>>)
File.write!(short, <<0x41, 0x42, 0x43>>)

torn =
  for _round <- 1..40, reduce: [] do
    acc ->
      results =
        1..64
        |> Enum.map(fn i ->
          path = if rem(i, 2) == 0, do: long, else: short

          Task.async(fn ->
            case Vix.Vips.Operation.thumbnail(path, 64) do
              {:error, reason} when is_binary(reason) -> reason
              _ -> nil
            end
          end)
        end)
        |> Task.await_many(120_000)
        |> Enum.reject(&is_nil/1)

      acc ++ Enum.filter(results, &(:binary.match(&1, <<0>>) != :nomatch or not String.valid?(&1)))
  end

IO.puts("torn reads: #{length(torn)} / 2560 error retrievals")

case torn do
  [] -> :ok
  [sample | _] ->
    [head, rest] = :binary.split(sample, <<0>>)
    IO.puts("  before NUL: #{inspect(head)}")
    IO.puts("  after NUL:  #{inspect(binary_part(rest, 0, min(byte_size(rest), 180)))}")
end
```

Output on an unpatched `master` (`ec9217c`, v0.40.0):

```
libvips 8.18.2, 16 dirty CPU schedulers
torn reads: 22 / 2560 error retrievals

example (648 bytes):
  before NUL: "operation build: "
  after NUL:  "ipsForeignLoad: \"/var/folders/.../vix_error_race/s.jpg\" is not a known file format\nVipsForeignLoad: \"/var/folders/..."
```

`strlen` measured ~647 bytes, another thread cleared the buffer, and the `memcpy` pulled 630 bytes of an unrelated task's error text into this task's `{:error, reason}`. Three consecutive runs: 22, 18, 20 per 2560.

Note that `VIX_COMPILATION_MODE` must be set to build `c_src` at all — under the default `PRECOMPILED_NIF_AND_LIBVIPS` the NIF is downloaded rather than compiled. I used `PLATFORM_PROVIDED_LIBVIPS` against Homebrew libvips 8.18.2.

Results at `ec9217c`, same machine and script:

| | unpatched | patched |
|---|---|---|
| torn reads, 3 runs of 2560 | 22 / 18 / 20 | **0 / 0 / 0** |
| `mix test` | 275 passed | 275 passed |

Compiles clean under the existing `-Wall -Werror -Wextra -std=c11`. Success paths, single-threaded error text, and the shape of `{:error, reason}` are all unchanged.

## What this does *not* fix

Because `vips_error_text` is one array shared by the whole process, a failing operation can still return an error raised by a *different* concurrent operation. Measured with per-task tagged errors (each task's file starts with unique bytes that libvips echoes back):

| concurrent failing ops | message quotes another op's error | op lost its own error entirely |
|---|---|---|
| 1 | 0 | 0 |
| 4 | 1 | 1 |
| 16 | 1 | 1 |
| 64 | 5 | 5 |
| 200 | 11 | 11 |

Those figures are *with* the patch applied — it does not measurably change them, and cannot: the mixing happens while the operation runs, not while the error is read. Genuinely fixing it needs a per-thread error buffer in libvips upstream. Flagging it only so the scope of the patch is clear; it is a separate conversation for the libvips tracker.

## Environment

* vix `master` at `ec9217c` (v0.40.0); also reproduced on 0.38.0 and 0.27.0, where the macro is byte-identical
* libvips 8.18.2 (Homebrew, `PLATFORM_PROVIDED_LIBVIPS`); also reproduced against the bundled precompiled 8.17.1
* Erlang/OTP 29.0.1 (ERTS 17.0.1), Elixir 1.20.2
* Darwin 24.6.0, arm64, 16 dirty CPU schedulers