### PR TITLE
Fix mutable operation crash and support `{:error, _}` from mutate callback

### DIFF
--- a/lib/vix/vips/image.ex
+++ b/lib/vix/vips/image.ex
@@ -1288,9 +1288,12 @@ defmodule Vix.Vips.Image do
 
   * The mutated image passed to the callback or
   * `:ok` or
-  * `{:ok, some_result}`
+  * `{:ok, some_result}` or
+  * `{:error, reason}`
 
-  Call returns updated image.
+  Call returns updated image. If the callback returns `{:error, reason}` the
+  mutated image is discarded and `{:error, reason}` is returned. Any other
+  return value raises `ArgumentError`.
 
   Example
 
@@ -1318,8 +1321,17 @@ defmodule Vix.Vips.Image do
           MutableImage.to_image(mut_image)
 
         {:ok, result} ->
-          {:ok, image} = MutableImage.to_image(mut_image)
-          {:ok, {image, result}}
+          with {:ok, image} <- MutableImage.to_image(mut_image) do
+            {:ok, {image, result}}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+
+        other ->
+          raise ArgumentError,
+                "mutate callback must return the mutated image, `:ok`, " <>
+                  "`{:ok, result}` or `{:error, reason}`, got: #{inspect(other)}"
       end
     after
       MutableImage.stop(mut_image)

--- a/lib/vix/vips/mutable_operation.ex
+++ b/lib/vix/vips/mutable_operation.ex
@@ -52,33 +52,31 @@ defmodule Vix.Vips.MutableOperation do
       # operations without optional arguments
       def unquote(func_name)(unquote_splicing(req_params)) do
         [mutable_image | rest_params] = unquote(req_params)
+        op_spec = unquote(Macro.escape(spec))
 
-        operation_cb = fn image ->
-          operation_call(
-            unquote(name),
-            [image | rest_params],
-            [],
-            unquote(Macro.escape(spec))
-          )
+        # cast before sending, so invalid arguments never reach the image process
+        with {:ok, arg_terms} <- cast_mutable_args(rest_params, [], op_spec) do
+          operation_cb = fn image ->
+            mutable_operation_call(unquote(name), image, arg_terms, op_spec)
+          end
+
+          GenServer.call(mutable_image.pid, {:operation, operation_cb})
         end
-
-        GenServer.call(mutable_image.pid, {:operation, operation_cb})
       end
     else
       # operations with optional arguments
       def unquote(func_name)(unquote_splicing(req_params), optional \\ []) do
         [mutable_image | rest_params] = unquote(req_params)
+        op_spec = unquote(Macro.escape(spec))
 
-        operation_cb = fn image ->
-          operation_call(
-            unquote(name),
-            [image | rest_params],
-            optional,
-            unquote(Macro.escape(spec))
-          )
+        # cast before sending, so invalid arguments never reach the image process
+        with {:ok, arg_terms} <- cast_mutable_args(rest_params, optional, op_spec) do
+          operation_cb = fn image ->
+            mutable_operation_call(unquote(name), image, arg_terms, op_spec)
+          end
+
+          GenServer.call(mutable_image.pid, {:operation, operation_cb})
         end
-
-        GenServer.call(mutable_image.pid, {:operation, operation_cb})
       end
     end
 

--- a/lib/vix/vips/operation/helper.ex
+++ b/lib/vix/vips/operation/helper.ex
@@ -264,7 +264,21 @@ defmodule Vix.Vips.Operation.Helper do
 
   def operation_call(name, args, opts, %{desc: _} = spec) do
     nif_args = cast_arguments_to_nif_terms(args, opts, spec.in_req_spec, spec.in_opt_spec)
+    nif_operation_call(name, nif_args, spec)
+  end
 
+  def cast_mutable_args(args, opts, %{in_req_spec: [_image_spec | args_spec]} = spec) do
+    {:ok, cast_arguments_to_nif_terms(args, opts, args_spec, spec.in_opt_spec)}
+  rescue
+    error in ArgumentError -> {:error, Exception.message(error)}
+  end
+
+  def mutable_operation_call(name, image, arg_terms, %{in_req_spec: [image_spec | _]} = spec) do
+    image_term = Type.to_nif_term(image_spec.type, image, image_spec.data)
+    nif_operation_call(name, [{image_spec.param_name, image_term} | arg_terms], spec)
+  end
+
+  defp nif_operation_call(name, nif_args, spec) do
     case Vix.Nif.nif_vips_operation_call(name, nif_args) do
       {:ok, nif_out_args} ->
         output_to_erl_terms(

--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -3,6 +3,7 @@ defmodule Vix.Vips.MutableImageTest do
 
   alias Vix.Vips.Image
   alias Vix.Vips.MutableImage
+  alias Vix.Vips.MutableOperation
 
   import Vix.Support.Images
 
@@ -80,6 +81,13 @@ defmodule Vix.Vips.MutableImageTest do
 
     assert {:error, "No such field"} ==
              Image.mutate(i, fn m -> MutableImage.update(m, "no-such-field", 0) end)
+  end
+
+  test "operation with invalid argument" do
+    {:ok, im} = Image.new_from_file(img_path("puppies.jpg"))
+    {:ok, mim} = MutableImage.new(im)
+
+    assert {:error, "value must be >= 0"} == MutableOperation.draw_flood(mim, [255], -1, 0)
   end
 
   test "mutate raises on unsupported callback return" do

--- a/test/vix/vips/mutable_image_test.exs
+++ b/test/vix/vips/mutable_image_test.exs
@@ -68,4 +68,25 @@ defmodule Vix.Vips.MutableImageTest do
 
     assert {:ok, _} = Vix.Vips.Image.mutate(i, & &1)
   end
+
+  test "mutate returns error from callback" do
+    {:ok, i} = Image.new_from_file(img_path("puppies.jpg"))
+
+    assert {:error, :boom} == Image.mutate(i, fn _ -> {:error, :boom} end)
+  end
+
+  test "mutate propagates failing MutableImage call" do
+    {:ok, i} = Image.new_from_file(img_path("puppies.jpg"))
+
+    assert {:error, "No such field"} ==
+             Image.mutate(i, fn m -> MutableImage.update(m, "no-such-field", 0) end)
+  end
+
+  test "mutate raises on unsupported callback return" do
+    {:ok, i} = Image.new_from_file(img_path("puppies.jpg"))
+
+    assert_raise ArgumentError, ~r/mutate callback must return.*got: nil/, fn ->
+      Image.mutate(i, fn _ -> nil end)
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses two things related to mutable operation errors.

### 1. Validation errors in `Vix.Vips.MutableOperation` kill the calling process

Passing an invalid argument to a `Vix.Vips.MutableOperation` function kills the calling process, and there is no way to rescue it:

```elixir
{:ok, img} = Vix.Vips.Image.build_image(10, 10, [0, 0, 0])

Vix.Vips.Image.mutate(img, fn mut ->
  Vix.Vips.MutableOperation.draw_flood(mut, [255, 0, 0], -1, 0)
end)
```

```
** (EXIT from #PID<0.350.0>) shell process exited with reason: an exception was raised:
    ** (ArgumentError) value must be >= 0
        (vix 0.40.0) lib/vix/g_object/int.ex:39: Vix.GObject.Int.validate_number_limits!/2
        (vix 0.40.0) lib/vix/g_object/int.ex:20: Vix.GObject.Int.to_nif_term/2
        (vix 0.40.0) lib/vix/vips/operation/helper.ex:18: anonymous fn/3 in Vix.Vips.Operation.Helper.input_to_nif_terms/2
        (elixir 1.20.2) lib/enum.ex:2622: Enum."-reduce/3-lists^foldl/2-0-"/3
        (vix 0.40.0) lib/vix/vips/operation/helper.ex:266: Vix.Vips.Operation.Helper.operation_call/4
        (vix 0.40.0) lib/vix/vips/mutable_image.ex:185: Vix.Vips.MutableImage.handle_call/3
        (stdlib 8.0.1) gen_server.erl:2470: :gen_server.try_handle_call/4
        (stdlib 8.0.1) gen_server.erl:2499: :gen_server.handle_msg/3
```

An invalid argument raises in the GenServer rather than in the caller. `MutableImage.new/1` uses `start_link`, so the caller dies with it, and `try/rescue`/`catch :exit` around the call does not work.

### 2. Callbacks returning an error tuple raise `CaseClauseError`

```elixir
{:ok, img} = Vix.Vips.Image.build_image(10, 10, [0, 0, 0])

Vix.Vips.Image.mutate(img, fn mut ->
  Vix.Vips.MutableImage.update(mut, "no-such-field", 0)
end)
```

```
** (CaseClauseError) no case clause matching:

    {:error, "No such field"}

    (vix 0.40.0) lib/vix/vips/image.ex:1313: Vix.Vips.Image.mutate/2
```

* `MutableImage.update/3`, `set/4`, `remove/2` and every `Vix.Vips.MutableOperation` function can return `{:error, term()}`, so they can all cause a raise
* `mutate/2`'s spec already includes `{:error, term()}`, so no spec change needed

### Changes

* Support returning `{:error, reason}` from the `mutate/2` callback. Backwards compatible, because code returning `{:error, reason}` today raises `CaseClauseError`.
* Cast mutable operation arguments in the caller, like `MutableImage.set/4` already does. Invalid arguments now return `{:error, reason}`
* Replace the bare `CaseClauseError` for invalid callback returns with an `ArgumentError` containing information about the accepted return shapes

The three existing callback return shapes are unchanged.

### After

```elixir
Vix.Vips.Image.mutate(img, fn mut ->
  Vix.Vips.MutableOperation.draw_flood(mut, [255, 0, 0], -1, 0)
end)
#=> {:error, "value must be >= 0"}
```

```elixir
Vix.Vips.Image.mutate(img, fn mut ->
  Vix.Vips.MutableImage.update(mut, "no-such-field", 0)
end)
#=> {:error, "No such field"}
```